### PR TITLE
Getting single items and lists with spaces in names

### DIFF
--- a/SPList.php
+++ b/SPList.php
@@ -65,7 +65,7 @@ class SPList
      */
     public function updateItem($id,$itemProperties)
     {
-        $itemProperties['__metadata'] = array('type' => $this->getListItemEntityType());  //append entity metadata type
+        $itemProperties['__metadata'] = array('type' => str_replace("%20","_x0020_",$this->getListItemEntityType()));  //append entity metadata type
         $options = array(
          'list' => $this->name,
          'id' => $id,
@@ -101,7 +101,7 @@ class SPList
      */
     public function addItem($itemProperties)
     {
-        $itemProperties['__metadata'] = array('type' => $this->getListItemEntityType());  //append entity metadata type
+        $itemProperties['__metadata'] = array('type' => str_replace("%20","_x0020_",$this->getListItemEntityType()));  //append entity metadata type
         $options = array(
          'list' => $this->name,
          'data' => $itemProperties,


### PR DESCRIPTION
phpSPO has moved my project light years forward. Thanks for putting this together. I added a function to request just a single item from a list in addition to getItems. I also found that lists with spaces in their names caused issues when adding or updating lists. So I added a str_replace on those functions to replace %20 with _x0020_ which works great. 

This allows you to use `$listTitle = 'List%20Name';` when the list name has a space.

Thanks again for great code! Hopefully you don't mind me jumping in with my two cents as I incorporate into my project.
