### PR TITLE
Fix typo in the preparePayload function within ClientQuery.  

### DIFF
--- a/src/runtime/ClientQuery.php
+++ b/src/runtime/ClientQuery.php
@@ -49,7 +49,7 @@ class ClientQuery
                 $payload = $this->parameters->toJson();
             }
             else{
-                $payload = json_encode($payload);
+                $payload = json_encode($this->parameters);
             }
         }
         return $payload;


### PR DESCRIPTION
Just a small fix for the ClientQuery#preparePayload() method.  This change should ensure that when your ClientQuery parameter is just an array, it gets properly encoded.

Thanks for the awesome library!