### PR TITLE
Minor refactor to support NTLM Authentication.

### DIFF
--- a/examples/NtlmConnectExample.php
+++ b/examples/NtlmConnectExample.php
@@ -1,0 +1,22 @@
+<?php
+
+
+
+require_once(__DIR__.'/../src/auth/NtlmAuthenticationContext.php');
+require_once 'Settings.php';
+
+
+use SharePoint\PHP\Client\NtlmAuthenticationContext;
+
+try {
+	/* @var $authCtx NtlmAuthenticationContext */
+	$authCtx = new NtlmAuthenticationContext($Settings['Url'], $Settings['UserName'], $Settings['Password']);
+	$authCtx->acquireTokenForUser($Settings['UserName'],$Settings['Password']);
+	echo 'You have been authenticated successfully\n';
+}
+catch (Exception $e) {
+	echo 'Authentication failed: ',  $e->getMessage(), "\n";
+}
+
+
+?>

--- a/src/auth/NtlmAuthenticationContext.php
+++ b/src/auth/NtlmAuthenticationContext.php
@@ -1,0 +1,16 @@
+<?php
+namespace SharePoint\PHP\Client;
+require_once('AuthenticationContext.php');
+class NtlmAuthenticationContext extends AuthenticationContext{
+	
+	public function __construct($url, $username, $password){
+		parent::__construct($url, false);
+		Requests::enableNtlmAuthentication($username, $password);
+	}
+	
+	public function acquireTokenForUser($username,$password){
+		$result = Requests::ntlmAuth($this->url, $username, $password, true);
+		$this->cookies = Requests::parseCookies($result);
+	}
+	
+}

--- a/src/utilities/Requests.php
+++ b/src/utilities/Requests.php
@@ -10,19 +10,54 @@ class Requests
 	 */
 	private static $sslVersion = null;
 
+	private static $curlopts = array(
+			CURLOPT_SSL_VERIFYHOST => false,
+			CURLOPT_SSL_VERIFYPEER => false,
+			CURLOPT_RETURNTRANSFER => true,
+	);
+	
+	public static function addCurlOpt($key, $value){
+		self::$curlopts[$key]=$value;
+	}
 
+	public static function enableNtlmAuthentication($username, $password){
+		self::addCurlOpt(CURLOPT_HTTPAUTH, CURLAUTH_NTLM);
+		self::addCurlOpt(CURLOPT_USERPWD, $username. ':' . $password);
+	}
+	
+	public static function enableCurlDebug(){
+		self::addCurlOpt(CURLOPT_VERBOSE, true);
+	}
+	
 	public static function setSslVersion($sslVersion)
 	{
 	    if (!is_int($sslVersion)) {
 	        throw new \InvalidArgumentException("SSL Version must be an integer");
 	    }
-	    self::$sslVersion = $sslVersion;
+	    self::addCurlOpt(CURLOPT_SSLVERSION, $sslVersion);
 	}
 
+	public static function ntlmAuth($url, $username, $password, $passHeaders=false){
+		$ch = Requests::initCurl($url);
+		curl_setopt($ch, CURLOPT_HEADER, true);
+		curl_setopt($ch, CURLOPT_USERPWD, $username. ':' . $password);
+		curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_NTLM);
+		$result = curl_exec($ch);
+		if ($result === false) {
+			throw new \Exception(curl_error($ch));
+		}
+		if($passHeaders){
+			$result=substr($result, 0, curl_getinfo($ch, CURLINFO_HEADER_SIZE));
+		}
+		curl_close($ch);
+		return $result;
+	}
+	
 	public static function post($url,$headers,$data=null,$passHeaders=false)
 	{
 		$ch = Requests::initCurl($url);
         curl_setopt($ch, CURLOPT_POST, 1);
+        
 		if($headers)
 		   curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
 		curl_setopt($ch, CURLOPT_HEADER, $passHeaders);
@@ -81,14 +116,8 @@ class Requests
     private static function initCurl($url)
     {
         $ch = curl_init();
-		if (!is_null(self::$sslVersion)) {
-		    curl_setopt($ch, CURLOPT_SSLVERSION, self::$sslVersion);
-		}
-        curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false);
-        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
-        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_URL, $url);
-        //curl_setopt($ch, CURLOPT_PROXY, '127.0.0.1:8888');
+        curl_setopt_array($ch, self::$curlopts);
         return $ch;
     }
 }


### PR DESCRIPTION
Using the NtlmAuthenticationContext class, in place of AuthenticationContext, allows the phpSPO client to connect to a Sharepoint instance that supports NTLM authentication (and not federated auth).