### PR TITLE
Taxonomy field class not found

### DIFF
--- a/src/ClientObject.php
+++ b/src/ClientObject.php
@@ -134,7 +134,12 @@ abstract class ClientObject
                 $clsName = $parts[2];
             }
         }
-        if ($clsName == "List") $clsName = "SPList";
+        
+        if ($clsName == "List"){
+        	$clsName = "SPList";        
+        }elseif($clsName == "TaxonomyField"){ 
+        	$clsName="Taxonomy\\$clsName";
+        }
         $clientObjectType = $baseNsName . "\\" . $clsName;
         $clientObject = new $clientObjectType($ctx);
         $clientObject->initClientObjectProperties($properties);


### PR DESCRIPTION
Minor change to account for the slightly different namespace used by the TaxonomyField class (SharePoint\PHP\Client\Taxonomy instead of SharePoint\PHP\Client)