### PR TITLE
fix typo and remove unnecessary use statement

### DIFF
--- a/src/OutlookServices/ContactCollection.php
+++ b/src/OutlookServices/ContactCollection.php
@@ -5,7 +5,6 @@ namespace Office365\PHP\Client\OutlookServices;
 
 use Office365\PHP\Client\Runtime\ClientActionCreateEntity;
 use Office365\PHP\Client\Runtime\ClientObjectCollection;
-use Office365\PHP\Client\Runtime\OData\ODataPayload;
 use Office365\PHP\Client\Runtime\ResourcePathEntity;
 
 class ContactCollection extends ClientObjectCollection

--- a/src/OutlookServices/MeetingMessageType.php
+++ b/src/OutlookServices/MeetingMessageType.php
@@ -10,6 +10,6 @@ class MeetingMessageType
     const MeetingRequest = "MeetingRequest";
     const MeetingCancelled = "MeetingCancelled";
     const MeetingAccepted = "MeetingAccepted";
-    const MeetingTenativelyAccepted = "MeetingTenativelyAccepted";
+    const MeetingTentativelyAccepted = "MeetingTentativelyAccepted";
     const MeetingDeclined = "MeetingDeclined";
 }


### PR DESCRIPTION
This PR fixes a simple typo so that `MeetingMessageType` constants line up with the values documented https://msdn.microsoft.com/en-us/office/office365/api/complex-types-for-mail-contacts-calendar#MeetingMessageType