### PR TITLE
add client secret to acquire token for user credential request

### DIFF
--- a/src/Runtime/Auth/AuthenticationContext.php
+++ b/src/Runtime/Auth/AuthenticationContext.php
@@ -109,14 +109,16 @@ class AuthenticationContext implements IAuthenticationContext
     /**
      * @param string $resource
      * @param string $clientId
+     * @param string $clientSecret
      * @param UserCredentials $credentials
      */
-    public function acquireTokenForUserCredential($resource, $clientId, $credentials)
+    public function acquireTokenForUserCredential($resource, $clientId, $clientSecret, $credentials)
     {
         $this->provider = new OAuthTokenProvider($this->authorityUrl);
         $parameters = array(
             'grant_type' => 'password',
             'client_id' => $clientId,
+            'client_secret' => $clientSecret,
             'username' => $credentials->Username,
             'password' => $credentials->Password,
             'scope' => 'openid',


### PR DESCRIPTION
This PR adds a necessary field to the `acquireTokenForUserCredential` request.

Without the `client_secret` field, I received an error like this:

```
POST https://login.microsoftonline.com/mediadev19.onmicrosoft.com/oauth2/token
```

```
Http Response Code: 401
```

```
Response:
stdClass Object
(
    [error] => invalid_client
    [error_description] => AADSTS70002: The request body must contain the following parameter: 'client_secret or client_assertion'.
Trace ID: 4f9ed816-6ba5-46b4-b215-bd2d0c1884c5
Correlation ID: 571ff7af-cc8f-4f81-a63a-e0600f1aecdf
Timestamp: 2016-12-09 20:15:59Z
    [error_codes] => Array
        (
            [0] => 70002
        )

    [timestamp] => 2016-12-09 20:15:59Z
    [trace_id] => 4f9ed816-6ba5-46b4-b215-bd2d0c1884c5
    [correlation_id] => 571ff7af-cc8f-4f81-a63a-e0600f1aecdf
)
```