### PR TITLE
Add mail/folder functionality

### DIFF
--- a/src/OutlookServices/FolderCollection.php
+++ b/src/OutlookServices/FolderCollection.php
@@ -1,0 +1,26 @@
+<?php
+
+
+namespace Office365\PHP\Client\OutlookServices;
+
+use Office365\PHP\Client\Runtime\ClientActionCreateEntity;
+use Office365\PHP\Client\Runtime\ClientObjectCollection;
+
+class FolderCollection extends ClientObjectCollection
+{
+
+    /**
+     * Creates a folder
+     * @param string $displayName name of new folder
+     * @return MailFolder
+     */
+    public function createFolder($displayName) {
+        $folder = new MailFolder($this->getContext(), $this->getResourcePath());
+        $folder->setProperty('DisplayName', $displayName);
+        $qry = new ClientActionCreateEntity($this, $folder);
+        $this->getContext()->addQuery($qry, $folder);
+        $this->addChild($folder);
+        return $folder;
+    }
+
+}

--- a/src/OutlookServices/MailFolder.php
+++ b/src/OutlookServices/MailFolder.php
@@ -4,6 +4,8 @@
 namespace Office365\PHP\Client\OutlookServices;
 
 
+use Office365\PHP\Client\Runtime\ResourcePathEntity;
+
 class MailFolder extends OutlookEntity
 {
     /**
@@ -12,4 +14,36 @@ class MailFolder extends OutlookEntity
      */
     public $ChildFolderCount;
 
+    /**
+     * @return MessageCollection
+     */
+    public function getMessages()
+    {
+        if (!$this->isPropertyAvailable("Messages")) {
+            $this->setProperty("Messages",
+                new MessageCollection($this->getContext(), new ResourcePathEntity(
+                    $this->getContext(),
+                    $this->getResourcePath(),
+                    "Messages"
+                )));
+        }
+        return $this->getProperty("Messages");
+    }
+
+    /**
+     * @return FolderCollection
+     */
+    public function getChildFolders()
+    {
+        if (!$this->isPropertyAvailable("ChildFolders")) {
+            $this->setProperty("ChildFolders",
+                new FolderCollection($this->getContext(), new ResourcePathEntity(
+                    $this->getContext(),
+                    $this->getResourcePath(),
+                    "ChildFolders"
+                )));
+        }
+
+        return $this->getProperty("ChildFolders");
+    }
 }

--- a/src/OutlookServices/Message.php
+++ b/src/OutlookServices/Message.php
@@ -3,6 +3,7 @@
 
 namespace Office365\PHP\Client\OutlookServices;
 use Office365\PHP\Client\Runtime\ClientActionInvokePostMethod;
+use Office365\PHP\Client\Runtime\ClientActionUpdateEntity;
 use Office365\PHP\Client\Runtime\OperationParameterCollection;
 
 
@@ -65,6 +66,27 @@ class Message extends Item
         $this->getContext()->addQuery($qry);
     }
 
+    /**
+     * Marks a message as read/unread
+     * @param bool $isRead whether or not the message is read
+     */
+    public function read($isRead)
+    {
+        $this->setProperty("IsRead", $isRead);
+        $qry = new ClientActionUpdateEntity($this);
+        $this->getContext()->addQuery($qry);
+    }
+
+    /**
+     * Marks a message as important/unimportant
+     * @param int $importance importance level (1,2,3)
+     */
+    public function important($importance)
+    {
+        $this->setProperty("Importance", $importance);
+        $qry = new ClientActionUpdateEntity($this);
+        $this->getContext()->addQuery($qry);
+    }
 
     /**
      * @param $attachmentType

--- a/src/OutlookServices/MessageCollection.php
+++ b/src/OutlookServices/MessageCollection.php
@@ -5,6 +5,7 @@ namespace Office365\PHP\Client\OutlookServices;
 
 use Office365\PHP\Client\Runtime\ClientActionCreateEntity;
 use Office365\PHP\Client\Runtime\ClientObjectCollection;
+use Office365\PHP\Client\Runtime\ResourcePathEntity;
 
 class MessageCollection extends ClientObjectCollection
 {
@@ -19,6 +20,23 @@ class MessageCollection extends ClientObjectCollection
         $this->getContext()->addQuery($qry, $message);
         $this->addChild($message);
         return $message;
+    }
+
+    /**
+     * @param $messageId
+     * @return Message
+     */
+    public function getMessage($messageId)
+    {
+        if (!$this->isPropertyAvailable("Messages")) {
+            $this->setProperty("Messages",
+                new Message($this->getContext(), new ResourcePathEntity(
+                    $this->getContext(),
+                    $this->getResourcePath(),
+                    $messageId
+                )));
+        }
+        return $this->getProperty("Messages");
     }
 
 }

--- a/src/OutlookServices/User.php
+++ b/src/OutlookServices/User.php
@@ -31,6 +31,39 @@ class User extends ClientObject
         return $this->getProperty("Messages");
     }
 
+    /**
+     * @param string $folderId
+     * @return MailFolder
+     */
+    public function getFolder($folderId)
+    {
+        if (!$this->isPropertyAvailable("Folders")) {
+            $this->setProperty("Folders",
+                new MailFolder($this->getContext(), new ResourcePathEntity(
+                    $this->getContext(),
+                    $this->getResourcePath(),
+                    "Folders/" . $folderId
+                )));
+        }
+        return $this->getProperty("Folders");
+    }
+
+    /**
+     * @return MailFolder
+     */
+    public function getFolders()
+    {
+        if (!$this->isPropertyAvailable("Folders")) {
+            $this->setProperty("Folders",
+                new MailFolder($this->getContext(), new ResourcePathEntity(
+                    $this->getContext(),
+                    $this->getResourcePath(),
+                    "Folders"
+                )));
+        }
+        return $this->getProperty("Folders");
+    }
+
 
     /**
      * @param Message $message

--- a/src/Runtime/ClientRequest.php
+++ b/src/Runtime/ClientRequest.php
@@ -7,6 +7,7 @@ use Exception;
 use Office365\PHP\Client\Runtime\OData\JsonPayloadSerializer;
 use Office365\PHP\Client\Runtime\OData\ODataFormat;
 use Office365\PHP\Client\Runtime\OData\ODataPayload;
+use Office365\PHP\Client\Runtime\OData\ODataQueryOptions;
 use Office365\PHP\Client\Runtime\Utilities\JsonConvert;
 use Office365\PHP\Client\Runtime\Utilities\RequestOptions;
 use Office365\PHP\Client\Runtime\Utilities\Requests;
@@ -217,13 +218,13 @@ class ClientRequest
 
     /**
      * @param ClientObject $clientObject
-     * @param array $selectProperties
+     * @param ODataQueryOptions $queryOptions
      */
-    public function addQueryAndResultObject(ClientObject $clientObject, array $selectProperties = null)
+    public function addQueryAndResultObject(ClientObject $clientObject, ODataQueryOptions $queryOptions = null)
     {
         $resourceUrl = $clientObject->getResourceUrl();
-        if (!is_null($selectProperties)) {
-            $resourceUrl .= "?\$select=" . implode(",", $selectProperties);
+        if (!is_null($queryOptions)) {
+            $resourceUrl .= '?' . $queryOptions->toUrl();
         }
         $qry = new ClientActionReadEntity($resourceUrl);
         $this->addQuery($qry, $clientObject);

--- a/src/Runtime/ClientRuntimeContext.php
+++ b/src/Runtime/ClientRuntimeContext.php
@@ -5,6 +5,7 @@ namespace Office365\PHP\Client\Runtime;
 use Office365\PHP\Client\Runtime\Auth\IAuthenticationContext;
 use Office365\PHP\Client\Runtime\OData\ODataFormat;
 use Office365\PHP\Client\Runtime\OData\ODataPayload;
+use Office365\PHP\Client\Runtime\OData\ODataQueryOptions;
 use Office365\PHP\Client\Runtime\Utilities\RequestOptions;
 
 /**
@@ -66,13 +67,13 @@ class ClientRuntimeContext
     /**
      * Prepare to load resource
      * @param ClientObject $clientObject
-     * @param array $selectProperties
+     * @param ODataQueryOptions $queryOptions
      *
      * @return self
      */
-    public function load(ClientObject $clientObject, array $selectProperties = null)
+    public function load(ClientObject $clientObject, ODataQueryOptions $queryOptions = null)
     {
-        $this->getPendingRequest()->addQueryAndResultObject($clientObject, $selectProperties);
+        $this->getPendingRequest()->addQueryAndResultObject($clientObject, $queryOptions);
         return $this;
     }
 

--- a/src/Runtime/OData/ODataQueryOptions.php
+++ b/src/Runtime/OData/ODataQueryOptions.php
@@ -31,14 +31,16 @@ class ODataQueryOptions
     }
 
     public $Select;
-    
+
     public $Filter;
 
     public $Expand;
-    
+
     public $OrderBy;
 
     public $Top;
 
     public $Skip;
+
+    public $Search;
 }


### PR DESCRIPTION
This PR adds some features to improve using this library for mail requests including:

1. Creating folders
2. Fetching child folders
3. Listing folders
4. Fetching a folder by id
5. Fetching messages in a folder
6. Marking a message as read/unread
7. Updating a message's importance level
8. Fetching a single message by id
9. Updating the query object to use an `ODataQueryOptions` instance, which allows the use of other query params, such as `$filter` or `$search` (previously it only supported `$select`).

I was not able to find these features poking through the code so I've added them here. 

Let me know if you've got any feedback on this, or if the library supports a different way of accessing those parts of the api. 

I think the most controversial change is adding the `ODataQueryOptions` object that could break something for an existing user. 