### PR TITLE
Add support for switching API versions

### DIFF
--- a/src/OutlookServices/OutlookClient.php
+++ b/src/OutlookServices/OutlookClient.php
@@ -20,10 +20,11 @@ use Office365\PHP\Client\Runtime\Utilities\RequestOptions;
 class OutlookClient extends ClientRuntimeContext
 {
 
-    public function __construct(IAuthenticationContext $authContext)
+    public function __construct(IAuthenticationContext $authContext, $version = Office365Version::V1)
     {
-        $this->serviceRootUrl = $this->serviceRootUrl . Office365Version::V1 . "/";
-        parent::__construct($this->serviceRootUrl, $authContext,new JsonFormat(ODataMetadataLevel::Verbose));
+        $this->version = $version;
+        $this->serviceRootUrl = $this->serviceRootUrl . $version . "/";
+        parent::__construct($this->serviceRootUrl, $authContext, new JsonFormat(ODataMetadataLevel::Verbose), $version);
     }
 
 
@@ -87,7 +88,10 @@ class OutlookClient extends ClientRuntimeContext
      */
     private $serviceRootUrl = "https://outlook.office365.com/api/";
 
-
+    /**
+     * @var string
+     */
+    public $version;
 
     /**
      * @var User

--- a/src/OutlookServices/User.php
+++ b/src/OutlookServices/User.php
@@ -5,6 +5,7 @@ namespace Office365\PHP\Client\OutlookServices;
 
 use Office365\PHP\Client\Runtime\ClientActionInvokePostMethod;
 use Office365\PHP\Client\Runtime\ClientObject;
+use Office365\PHP\Client\Runtime\Office365Version;
 use Office365\PHP\Client\Runtime\OperationParameterCollection;
 use Office365\PHP\Client\Runtime\ResourcePathEntity;
 
@@ -42,7 +43,7 @@ class User extends ClientObject
                 new MailFolder($this->getContext(), new ResourcePathEntity(
                     $this->getContext(),
                     $this->getResourcePath(),
-                    "Folders/" . $folderId
+                    $this->getFolderEntityName() . "/" . $folderId
                 )));
         }
         return $this->getProperty("Folders");
@@ -58,7 +59,7 @@ class User extends ClientObject
                 new MailFolder($this->getContext(), new ResourcePathEntity(
                     $this->getContext(),
                     $this->getResourcePath(),
-                    "Folders"
+                    $this->getFolderEntityName()
                 )));
         }
         return $this->getProperty("Folders");
@@ -176,6 +177,21 @@ class User extends ClientObject
                 ));
         }
         return $this->getProperty("Calendar");
+    }
+
+
+    /**
+     * @return string
+     * @throws \Exception
+     */
+    private function getFolderEntityName()
+    {
+        if ($this->getContext()->getApiVersion() == Office365Version::V1)
+            return "Folders";
+        if ($this->getContext()->getApiVersion() == Office365Version::V2)
+            return "MailFolders";
+
+        throw new \Exception("Unknown API version '" . $this->getContext()->getApiVersion() . "'");
     }
 
 

--- a/src/Runtime/ClientRuntimeContext.php
+++ b/src/Runtime/ClientRuntimeContext.php
@@ -15,9 +15,15 @@ class ClientRuntimeContext
 {
     /**
      * Service Root url
-     * @var Url
+     * @var string
      */
     private $serviceRootUrl;
+
+    /**
+     * Service version
+     * @var string
+     */
+    private $version;
 
     /**
      * @var IAuthenticationContext
@@ -39,9 +45,11 @@ class ClientRuntimeContext
      * @param string $serviceUrl
      * @param IAuthenticationContext $authContext
      * @param ODataFormat $format
+     * @param string $version
      */
-    public function __construct($serviceUrl, IAuthenticationContext $authContext, ODataFormat $format)
+    public function __construct($serviceUrl, IAuthenticationContext $authContext, ODataFormat $format, $version = Office365Version::V1)
     {
+        $this->version = $version;
         $this->serviceRootUrl = $serviceUrl;
         $this->authContext = $authContext;
         $this->format = $format;
@@ -62,6 +70,15 @@ class ClientRuntimeContext
     public function getServiceRootUrl()
     {
         return $this->serviceRootUrl;
+    }
+
+    /**
+     * Gets the api version being used
+     * @return string
+     */
+    public function getApiVersion()
+    {
+        return $this->version;
     }
 
     /**


### PR DESCRIPTION
This PR allows the user to specify which client version they'd like to use (defaults to V1 which was the previous behavior).

This includes handling for the different paths required by the `MailFolders` endpoint (previously `/Folders` in V1.

See docs here: https://msdn.microsoft.com/en-us/office/office365/api/mail-rest-operations#GetFolders