### PR TITLE
add method to set curl options

### DIFF
--- a/examples/SharePoint/file_examples.php
+++ b/examples/SharePoint/file_examples.php
@@ -62,6 +62,7 @@ function processFiles(SPList $list,$targetPath)
         //approveFile($ctx,$file->ServerRelativeUrl);
         $fileName = $targetPath . "/" . basename($file->ServerRelativeUrl);
         downloadFile($ctx,$file->ServerRelativeUrl,$fileName);
+        //downloadFileAsStream($ctx,$file->ServerRelativeUrl,$fileName);
     }
 }
 
@@ -149,5 +150,18 @@ function saveFile(ClientContext $ctx, $sourceFilePath, $targetFileUrl)
 function downloadFile(ClientRuntimeContext $ctx, $fileUrl, $targetFilePath){
     $fileContent = Office365\PHP\Client\SharePoint\File::openBinary($ctx,$fileUrl);
     file_put_contents($targetFilePath, $fileContent);
+    print "File {$fileUrl} has been downloaded successfully\r\n";
+}
+
+function downloadFileAsStream(ClientRuntimeContext $ctx, $fileUrl, $targetFilePath) {
+    $fileUrl = rawurlencode($fileUrl);
+
+    $fp = fopen($targetFilePath, 'w+');
+    $url = $ctx->getServiceRootUrl() . "web/getfilebyserverrelativeurl('$fileUrl')/\$value";
+    $options = new \Office365\PHP\Client\Runtime\Utilities\RequestOptions($url);
+    $options->addCurlOption(CURLOPT_FILE, $fp);
+    $ctx->executeQueryDirect($options);
+    fclose($fp);
+
     print "File {$fileUrl} has been downloaded successfully\r\n";
 }

--- a/examples/SharePoint/file_examples.php
+++ b/examples/SharePoint/file_examples.php
@@ -159,7 +159,7 @@ function downloadFileAsStream(ClientRuntimeContext $ctx, $fileUrl, $targetFilePa
     $fp = fopen($targetFilePath, 'w+');
     $url = $ctx->getServiceRootUrl() . "web/getfilebyserverrelativeurl('$fileUrl')/\$value";
     $options = new \Office365\PHP\Client\Runtime\Utilities\RequestOptions($url);
-    $options->addCurlOption(CURLOPT_FILE, $fp);
+    $options->StreamHandle = $fp;
     $ctx->executeQueryDirect($options);
     fclose($fp);
 

--- a/src/Runtime/Utilities/RequestOptions.php
+++ b/src/Runtime/Utilities/RequestOptions.php
@@ -27,7 +27,7 @@ class RequestOptions
         $this->UserCredentials = null;
         $this->Verbose = false;
         $this->SSLVersion = null;
-        $this->curlOptions = array();
+        $this->StreamHandle = null;
     }
 
     public function toArray()
@@ -43,13 +43,8 @@ class RequestOptions
             'Verbose' => $this->Verbose,
             'UserCredentials' => $this->UserCredentials,
             'SSLVersion' => $this->SSLVersion,
-            'CurlOptions' => $this->curlOptions,
+            'StreamHandle' => $this->StreamHandle,
         ];
-    }
-
-    public function addCurlOption($name, $value)
-    {
-        $this->curlOptions[$name] = $value;
     }
 
     public function addCustomHeader($name, $value)
@@ -135,8 +130,8 @@ class RequestOptions
 
 
     /**
-     * @var array
+     * @var resource
      */
-    public $curlOptions;
+    public $StreamHandle;
 
 }

--- a/src/Runtime/Utilities/RequestOptions.php
+++ b/src/Runtime/Utilities/RequestOptions.php
@@ -27,6 +27,7 @@ class RequestOptions
         $this->UserCredentials = null;
         $this->Verbose = false;
         $this->SSLVersion = null;
+        $this->curlOptions = array();
     }
 
     public function toArray()
@@ -42,9 +43,14 @@ class RequestOptions
             'Verbose' => $this->Verbose,
             'UserCredentials' => $this->UserCredentials,
             'SSLVersion' => $this->SSLVersion,
+            'CurlOptions' => $this->curlOptions,
         ];
     }
 
+    public function addCurlOption($name, $value)
+    {
+        $this->curlOptions[$name] = $value;
+    }
 
     public function addCustomHeader($name, $value)
     {
@@ -126,5 +132,11 @@ class RequestOptions
      * @var int
      */
     public $SSLVersion;
+
+
+    /**
+     * @var array
+     */
+    public $curlOptions;
 
 }

--- a/src/Runtime/Utilities/Requests.php
+++ b/src/Runtime/Utilities/Requests.php
@@ -95,7 +95,6 @@ class Requests
         $ch = curl_init();
         curl_setopt($ch, CURLOPT_URL, $options->Url);
         curl_setopt_array($ch, self::$defaultOptions);  //default options
-        curl_setopt_array($ch, $options->curlOptions);  //custom options
         //include headers in response
         curl_setopt($ch, CURLOPT_HEADER, $options->IncludeHeaders);
         //include body in response
@@ -110,6 +109,8 @@ class Requests
         //set Post Body
         if(isset($options->Data))
             curl_setopt($ch, CURLOPT_POSTFIELDS, $options->Data);
+        if(is_resource($options->StreamHandle))
+            curl_setopt($ch, CURLOPT_FILE, $options->StreamHandle);
         $options->addCustomHeader("content-length",strlen($options->Data));
         //custom HTTP headers
         if($options->Headers)

--- a/src/Runtime/Utilities/Requests.php
+++ b/src/Runtime/Utilities/Requests.php
@@ -95,6 +95,7 @@ class Requests
         $ch = curl_init();
         curl_setopt($ch, CURLOPT_URL, $options->Url);
         curl_setopt_array($ch, self::$defaultOptions);  //default options
+        curl_setopt_array($ch, $options->curlOptions);  //custom options
         //include headers in response
         curl_setopt($ch, CURLOPT_HEADER, $options->IncludeHeaders);
         //include body in response


### PR DESCRIPTION
…with file download example.

I was looking for a way to download files as stream (e.g. to avoid having the contents of a large file in memory). Tampering with  [OpenBinaryStream](https://msdn.microsoft.com/en-us/library/office/dn450841.aspx#bk_FileOpenBinaryStream) did not work, somehow, I always got the file content. 

Instead, it works when specifying the CURLOPT_FILE options (and the usual $value endpoint). This PR provides a method to insert curl options to RequestOptions.

Another thing that is a bit related but I left untouched for now are the insecure default curl options. A more central place to change them for any request would be pretty nice.