### PR TITLE
Add digest to file save request, SP refuses the operation otherwise

### DIFF
--- a/src/SharePoint/File.php
+++ b/src/SharePoint/File.php
@@ -159,6 +159,9 @@ class File extends SecurableObject
          $request->Method = HttpMethod::Post;
          $request->addCustomHeader('X-HTTP-Method','PUT');
          $request->Data = $content;
+         if($ctx instanceof ClientContext) {
+             $ctx->ensureFormDigest($request);
+         }
          $ctx->executeQueryDirect($request);
      }
 


### PR DESCRIPTION
@vgrem I've got another one for you.

SharePoint requires the digest. Without, I'll only get this error message when attempting to upload a file:

```json
{
    "error": {
        "code": "-2130575251, Microsoft.SharePoint.SPException",
        "message": {
            "lang": "en-US",
            "value": "The security validation for this page is invalid and might be corrupted. Please use your web browser's Back button to try your operation again."
        }
    }
}
```

The if could be omitted if only accepting ``ClientContext`` as parameter. I refrained from it, in order to not break other use cases accidentally.

