### PR TITLE
removes queries on the go so they don't get stuck on exceptions

### DIFF
--- a/src/Runtime/ClientRequest.php
+++ b/src/Runtime/ClientRequest.php
@@ -123,7 +123,7 @@ class ClientRequest
     public function executeQuery()
     {
         $serializer = new JsonPayloadSerializer($this->format);
-        foreach ($this->queries as $qry) {
+        while(($qry = array_shift($this->queries)) !== null) {
             $request = $this->buildRequest($qry);
             if (is_callable($this->eventsList["BeforeExecuteQuery"])) {
                 call_user_func_array($this->eventsList["BeforeExecuteQuery"], array(
@@ -151,7 +151,6 @@ class ClientRequest
                 }
             }
         }
-        $this->queries = array();
     }
 
     /**


### PR DESCRIPTION
When one query fails with an exception, the queue is not cleared, because ``ClientRequest::executeQuery()`` is left earlier. Thus, using the context again will always trigger this query (and also already run queries), and will always fail.

Simplified use case: 

1. Fetch File A from SharePoint
2. Try to fetch not existing File B from SharePoint, catch the Exception it as it is an valid outcome
3. Any other requests from within the same context will fail, because this query is not removed.
4. Recreate a new context (null the old one)
5. Trigger an action on File A (e.g. recycle())
6. → Fails, because File A is bound to the old context
7. → Fails also with getContext() on File A, because of 3.

Three possible solutions: 
a) remove the faulty request before throwing the Exception
b) remove the current query unconditionally
c) offer a way to clean up registered queries. 

I implemented ``b`` in this PR, because it sounds most reasonable for me. Way a) would leave earlier queries in the queue, while way c) would let to a lot of unnecessary handling which is being done in one place now. 

@vgrem Or have the queries been kept in place for some reason?

The alternative of having a context for each file or folder object is rather nightmarish.

