### PR TITLE
Syntax fixed for PHP < 7.1

### DIFF
--- a/src/SharePoint/Publishing/VideoProcessingStatus.php
+++ b/src/SharePoint/Publishing/VideoProcessingStatus.php
@@ -7,6 +7,6 @@ namespace Office365\PHP\Client\SharePoint\Publishing;
 class VideoProcessingStatus
 {
 
-    public const  PendingProcessing = 0;
-    public const  Processing = 1;
+    const  PendingProcessing = 0;
+    const  Processing = 1;
 }


### PR DESCRIPTION
const visibility can  be set with PHP 7.1 only, fails on earlier supported versions.