### PR TITLE
fix parsing of array properties such as OutlookServices/Message ToRecipients field

### DIFF
--- a/src/Runtime/ClientObject.php
+++ b/src/Runtime/ClientObject.php
@@ -151,8 +151,6 @@ class ClientObject extends ODataPayload
                         $this->setProperty($key, $value, false);
                     }
                 }
-            } elseif (is_array($value)) {
-                $this->convertFromJson($value);
             } else {
                 $this->setProperty($key, $value, false);
             }

--- a/src/Runtime/OData/ODataPayload.php
+++ b/src/Runtime/OData/ODataPayload.php
@@ -87,7 +87,7 @@ abstract class ODataPayload
      */
     protected function isMetadataProperty($key)
     {
-        return $key == "__metadata";
+        return $key === "__metadata";
     }
 
     protected function isDeferredProperty($value)


### PR DESCRIPTION
Found a couple of small issues that prevented the `OutlookServices/Message` object from being converted to json as expected.

First, I made the `isMetadataProperty` check more strict, since `"__metadata" == 0` in php. This was causing arrays to be skipped because the `$key` in the case of an array value is numeric and indexed at 0.

Then I also got rid of the `convertFromJson`  for array properties because it doesn't appear to have been necessary to begin with. This is what fixed the problem for me.