### PR TITLE
Add clear method to clientRequest

### DIFF
--- a/src/Runtime/ClientRequest.php
+++ b/src/Runtime/ClientRequest.php
@@ -134,4 +134,12 @@ abstract class ClientRequest
         return $this->queries;
     }
 
+    /**
+     * Clears all queries and resultObjects.
+     */
+    public function clear()
+    {
+        $this->queries = [];
+        $this->resultObjects = [];
+    }
 }


### PR DESCRIPTION
The clear method makes the queries and resultObjects empty.

See https://github.com/vgrem/phpSPO/issues/129 for a possible use case.