### PR TITLE
Add method to remove the pending request of the client

### DIFF
--- a/src/Runtime/ClientRuntimeContext.php
+++ b/src/Runtime/ClientRuntimeContext.php
@@ -196,6 +196,17 @@ class ClientRuntimeContext
     }
 
     /**
+     * Removes the pending request.
+     */
+    public function removePendingRequest()
+    {
+        if (!isset($this->pendingRequest)) {
+            return;
+        }
+        unset($this->pendingRequest);
+    }
+
+    /**
      * @return Version
      */
     public function getServerLibraryVersion(){


### PR DESCRIPTION
I was a little bit to trigger happy on https://github.com/vgrem/phpSPO/pull/130 as the `client` in #130 is not available to me in this example https://github.com/vgrem/phpSPO/issues/129

```php
$this->setupFirstQuery();
try {
    $this->client->executeQuery();
} catch (Exception $e) {
   $this->client->clear();
    $this->setupSecondQuery();
    $this->client->executeQuery();
}
```

This merge request adds a `removePendingRequest()` method to the `ClientRuntimeContext` which is available to the code example above.
The result would be:
```php
$this->setupFirstQuery();
try {
    $this->client->executeQuery();
} catch (Exception $e) {
   $this->client->removePendingRequest();
    $this->setupSecondQuery();
    $this->client->executeQuery();
}
```

I'm sorry for the confusion. The `clear()` method from #130 might not be that useful so we could consider removing it again...