### PR TITLE
Add cURL timeout option

### DIFF
--- a/src/Runtime/Utilities/RequestOptions.php
+++ b/src/Runtime/Utilities/RequestOptions.php
@@ -29,6 +29,7 @@ class RequestOptions
         $this->SSLVersion = null;
         $this->StreamHandle = null;
         $this->Data = $data;
+        $this->connectTimeout = null;
     }
 
     public function toArray()
@@ -131,4 +132,9 @@ class RequestOptions
      */
     public $Proxy;
 
+
+    /**
+     * @var ?int
+     */
+    public $connectTimeout;
 }

--- a/src/Runtime/Utilities/Requests.php
+++ b/src/Runtime/Utilities/Requests.php
@@ -129,6 +129,8 @@ class Requests
             curl_setopt($ch,CURLOPT_HTTPAUTH, $options->AuthType);
         if(!is_null($options->UserCredentials))
             curl_setopt($ch,CURLOPT_USERPWD, $options->UserCredentials->toString());
+        if(!is_null($options->connectTimeout))
+            curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, $options->connectTimeout);
 
         return $ch;
     }


### PR DESCRIPTION
When a server is not available, cURL wasn't configured to timeout. It resulted in a PHP execution timeout.
This PR fixes this issue by adding an option to allow configuring the timeout. Its default value is `null` as a BC, so the previous behavior is kept.