### PR TITLE
Fix the null-parameter issue

### DIFF
--- a/src/Runtime/Utilities/Requests.php
+++ b/src/Runtime/Utilities/Requests.php
@@ -103,7 +103,7 @@ class Requests
         //Set method
         if($options->Method == HttpMethod::Post) {
            curl_setopt($ch, CURLOPT_POST, 1);
-           if (!array_key_exists('Content-Length', $options->Headers)) {
+           if (is_array($options->Headers) && !array_key_exists('Content-Length', $options->Headers)) {
               $options->addCustomHeader("Transfer-Encoding", "chunked");
            }
         } else if($options->Method == HttpMethod::Patch) {


### PR DESCRIPTION
Fix `array_key_exists() expects parameter 2 to be array, null given in /home/travis/build/vgrem/phpSPO/src/Runtime/Utilities/Requests.php on line 106` issue (see #147)