### PR TITLE
Fix method attribute defined as a boolean instead of a string

### DIFF
--- a/src/Runtime/Utilities/RequestOptions.php
+++ b/src/Runtime/Utilities/RequestOptions.php
@@ -67,7 +67,7 @@ class RequestOptions
 
 
     /**
-     * @var bool
+     * @var string
      */
     public $Method;
 


### PR DESCRIPTION
The `Office365\PHP\Client\Runtime\Utilities\RequestOptions::Method` attribute is currently defined as a boolean via PhpDoc, but all its usages give it a string value. Fixing the PhpDoc.

PS: may I suggest you to add [PHPStan](https://github.com/phpstan/phpstan) to the project? It's a tool that checks for error in the code. With a level of 5, it is able to verify this kind of error. It can also be used on your CI.
You may also want to add [PHP-CS-Fixer](https://github.com/FriendsOfPhp/PHP-CS-Fixer), a tool that checks that the code respects some given coding standard. These tools are very common in the PHP land and very useful to ensure the stability of the code.