### PR TITLE
Accepting PUT option when executing curl request

### DIFF
--- a/src/Runtime/Utilities/Requests.php
+++ b/src/Runtime/Utilities/Requests.php
@@ -105,6 +105,8 @@ class Requests
            curl_setopt($ch, CURLOPT_POST, 1);
         } else if($options->Method == HttpMethod::Patch) {
            curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $options->Method);
+        } else if($options->Method == HttpMethod::Put) {
+           curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $options->Method);
         } else if($options->Method == HttpMethod::Delete) {
             curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $options->Method);
         }


### PR DESCRIPTION
In Runtime/Utilities/Requests::init() I added a handler method for PUT
request types since at the moment only POST, PATCH, and DELETE are
accounted for.

This helped resolve some method not allowed errors I was getting when
running requests on the graph API.