### PR TITLE
Add Transfer-Encoding: chunked header if no content length is provided (SharePoint only)

### DIFF
--- a/src/Runtime/ClientRequest.php
+++ b/src/Runtime/ClientRequest.php
@@ -128,14 +128,15 @@ abstract class ClientRequest
     /**
      * @param RequestOptions $request
      * @param array $responseInfo
+     * @param bool $transferEncodingChunkedAllowed
      * @return string
      * @throws \Exception
      */
-    public function executeQueryDirect(RequestOptions $request,&$responseInfo=array())
+    public function executeQueryDirect(RequestOptions $request, &$responseInfo = array(), bool $transferEncodingChunkedAllowed = false)
     {
         $this->context->authenticateRequest($request); //Auth mandatory headers
         $this->setRequestHeaders($request); //set request headers
-        return Requests::execute($request,$responseInfo);
+        return Requests::execute($request,$responseInfo, $transferEncodingChunkedAllowed);
     }
 
     /**

--- a/src/Runtime/ClientRuntimeContext.php
+++ b/src/Runtime/ClientRuntimeContext.php
@@ -145,12 +145,15 @@ class ClientRuntimeContext
 
     /**
      * @param RequestOptions $options
+     * @param bool $transferEncodingChunkedAllowed
      * @return string
      * @throws \Exception
      */
-    public function executeQueryDirect(RequestOptions $options)
+    public function executeQueryDirect(RequestOptions $options, bool $transferEncodingChunkedAllowed = false)
     {
-        return $this->getPendingRequest()->executeQueryDirect($options);
+        // $_ is not used, just to avoid the "Only variables can be passed by reference" error
+        $_ = [];
+        return $this->getPendingRequest()->executeQueryDirect($options, $_, $transferEncodingChunkedAllowed);
     }
 
     /**

--- a/src/SharePoint/ClientContext.php
+++ b/src/SharePoint/ClientContext.php
@@ -64,7 +64,7 @@ class ClientContext extends ClientRuntimeContext
     {
         $request = new RequestOptions($this->getServiceRootUrl() . "contextinfo");
         $request->Method = HttpMethod::Post;
-        $response = $this->executeQueryDirect($request);
+        $response = $this->executeQueryDirect($request, true);
         if(!isset($this->contextWebInformation))
             $this->contextWebInformation = new ContextWebInformation();
         $result = new ClientResult($this->contextWebInformation);

--- a/src/SharePoint/File.php
+++ b/src/SharePoint/File.php
@@ -164,7 +164,7 @@ class File extends SecurableObject
         $serverRelativeUrl = rawurlencode($serverRelativeUrl);
         $url = $ctx->getServiceRootUrl() . "web/getfilebyserverrelativeurl('$serverRelativeUrl')/\$value";
         $options = new RequestOptions($url);
-        $data = $ctx->executeQueryDirect($options);
+        $data = $ctx->executeQueryDirect($options, true);
         return $data;
     }
 
@@ -187,7 +187,7 @@ class File extends SecurableObject
         if ($ctx instanceof ClientContext) {
             $ctx->ensureFormDigest($request);
         }
-        $ctx->executeQueryDirect($request);
+        $ctx->executeQueryDirect($request, true);
     }
 
 

--- a/src/SharePoint/ListItem.php
+++ b/src/SharePoint/ListItem.php
@@ -36,7 +36,7 @@ class ListItem extends SecurableObject
             //determine whether ListItemEntityTypeFullName property has been requested
             if(!$list->isPropertyAvailable("ListItemEntityTypeFullName")){
                 $request = new RequestOptions($list->getResourceUrl() . "?\$select=ListItemEntityTypeFullName");
-                $response = $this->getContext()->executeQueryDirect($request);
+                $response = $this->getContext()->executeQueryDirect($request, true);
                 $payload = json_decode($response);
                 $this->getContext()->getSerializerContext()->map($payload,$list);
             }

--- a/src/SharePoint/Publishing/VideoItem.php
+++ b/src/SharePoint/Publishing/VideoItem.php
@@ -37,7 +37,7 @@ class VideoItem extends ClientObject
         $request->Data = $content;
         if($ctx instanceof ClientContext)
             $ctx->ensureFormDigest($request);
-        $ctx->executeQueryDirect($request);
+        $ctx->executeQueryDirect($request, true);
     }
 
 


### PR DESCRIPTION
This is a revamp of #147 with a fix of the BC-break mentioned in https://github.com/vgrem/phpSPO/pull/147#issuecomment-507994711.

It's mainly the same as the older PR, but we add a new argument to the common methods with a default value to disable the `Transfer-Encoding` header by default, which ensures we won't get BC-break on the other parts of the library.