### PR TITLE
Throw an exception if getting a file failed

### DIFF
--- a/src/Exception/IOException.php
+++ b/src/Exception/IOException.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Office365\PHP\Client\Exception;
+
+/**
+ * An exception thrown if the remote service returns an error.
+ */
+class IOException extends \Exception
+{
+    /**
+     * @var string|null
+     */
+    private $responseBody;
+
+    /**
+     * IOException constructor.
+     * @param string $message an error message for the logs
+     * @param int $statusCode the HTTP status code returned by the remote service
+     * @param string|null $responseBody the body of the remote service response.
+     */
+    public function __construct($message, $statusCode = 0, $responseBody = null)
+    {
+        parent::__construct($message, $statusCode);
+        $this->responseBody = $responseBody;
+    }
+
+    /**
+     * The response returned by the remote service, or `null` if the body was empty.
+     *
+     * @return string|null
+     */
+    public function getResponseBody()
+    {
+        return $this->responseBody;
+    }
+}
+

--- a/src/Runtime/ClientResponse.php
+++ b/src/Runtime/ClientResponse.php
@@ -14,6 +14,11 @@ abstract class ClientResponse
         $this->StatusCode = $details['HttpCode'];
     }
 
+    public function getStatusCode()
+    {
+        return $this->StatusCode;
+    }
+
     public function getContent(){
         return $this->Content;
     }

--- a/src/SharePoint/File.php
+++ b/src/SharePoint/File.php
@@ -1,6 +1,8 @@
 <?php
 
 namespace Office365\PHP\Client\SharePoint;
+
+use Office365\PHP\Client\Exception\IOException;
 use Office365\PHP\Client\Runtime\ClientResult;
 use Office365\PHP\Client\Runtime\DeleteEntityQuery;
 use Office365\PHP\Client\Runtime\InvokePostMethodQuery;
@@ -166,6 +168,14 @@ class File extends SecurableObject
         $options = new RequestOptions($url);
         $options->TransferEncodingChunkedAllowed = true;
         $response = $ctx->executeQueryDirect($options);
+        if (400 <= $statusCode = $response->getStatusCode()) {
+            throw new IOException(sprintf(
+                'Could not open file located at "%s". SharePoint has responded with status code %d, error was: %s',
+                rawurldecode($serverRelativeUrl),
+                $statusCode,
+                $response->getContent()
+            ), $statusCode, $response->getContent());
+        }
         return $response->getContent();
     }
 


### PR DESCRIPTION
Currently, when we request a file from SharePoint through `openBinary()`, the returned content is returned directly, even if it is actually an error.
Here we add a control on this and throw a new `IOException` exception (created for the occasion) if SharePoint returns an error (status code ≥ 400).

:fire: **Warning:** this is a BC-break!