### PR TITLE
Throw a more specific exception when cURL fails fetching the server

### DIFF
--- a/src/Exception/UnavailableServerException.php
+++ b/src/Exception/UnavailableServerException.php
@@ -1,0 +1,23 @@
+<?php
+
+
+namespace Office365\PHP\Client\Exception;
+
+
+use Throwable;
+
+/**
+ * This exception is thrown when an error occurs while trying to fetch the server.
+ * It has the following fields:
+ * - `message`: a readable for human beings error message (given by cURL);
+ * - `code`: the error code given by cURL.
+ *
+ * @see libcurl error codes available: https://curl.haxx.se/libcurl/c/libcurl-errors.html
+ */
+class UnavailableServerException extends \Exception
+{
+    public function __construct($message = '', $code = 0)
+    {
+        parent::__construct($message, $code);
+    }
+}

--- a/src/Runtime/Utilities/Requests.php
+++ b/src/Runtime/Utilities/Requests.php
@@ -1,6 +1,7 @@
 <?php
 namespace Office365\PHP\Client\Runtime\Utilities;
 
+use Office365\PHP\Client\Exception\UnavailableServerException;
 use Office365\PHP\Client\Runtime\HttpMethod;
 
 class Requests
@@ -32,7 +33,7 @@ class Requests
         $call['response'] = $response;
 
         if ($response === false) {
-            throw new \Exception(curl_error($ch));
+            throw new UnavailableServerException(curl_error($ch), curl_errno($ch));
         }
         curl_close($ch);
 


### PR DESCRIPTION
Throwing a new, more specific exception when upstream server does not respond for some reason (e.g. it is down), instead of PHP's too much generic `\Exception`. This way, developers can do some specific actions when this happens, such as displaying a message to end user, or renew the request to another server.

The exception's message contains the exact error returned by cURL, and `code` is the exact cURL errno (see https://curl.haxx.se/libcurl/c/libcurl-errors.html).