### PR TITLE
Out of memory exception is fixed for large files.

### DIFF
--- a/src/Runtime/Http/RequestOptions.php
+++ b/src/Runtime/Http/RequestOptions.php
@@ -144,4 +144,9 @@ class RequestOptions
      * @var bool
      */
     public $TransferEncodingChunkedAllowed;
+    
+    /**
+     * @var File pointer
+     */
+    public $OutputFile;
 }

--- a/src/Runtime/Http/Requests.php
+++ b/src/Runtime/Http/Requests.php
@@ -149,6 +149,8 @@ class Requests
             curl_setopt($ch,CURLOPT_USERPWD, $options->UserCredentials->toString());
         if(!is_null($options->ConnectTimeout))
             curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, $options->ConnectTimeout);
+        if(!is_null($options->OutputFile))
+            curl_setopt($ch, CURLOPT_FILE, $options->OutputFile);
 
         return $ch;
     }

--- a/src/SharePoint/File.php
+++ b/src/SharePoint/File.php
@@ -166,12 +166,13 @@ class File extends SecurableObject
      * @return mixed|string
      * @throws Exception
      */
-    public static function openBinary(ClientRuntimeContext $ctx, $serverRelativeUrl)
+    public static function openBinary(ClientRuntimeContext $ctx, $serverRelativeUrl, $outFile = NULL)
     {
         $serverRelativeUrl = rawurlencode($serverRelativeUrl);
         $url = $ctx->getServiceRootUrl() . "web/getfilebyserverrelativeurl('{$serverRelativeUrl}')/\$value";
         $options = new RequestOptions($url);
         $options->TransferEncodingChunkedAllowed = true;
+        $options->OutputFile = $outFile;
         $response = $ctx->executeQueryDirect($options);
         if (400 <= ($statusCode = $response->getStatusCode())) {
             throw new RequestException(sprintf('Could not open file located at "%s". SharePoint has responded with status code %d, error was: %s', rawurldecode($serverRelativeUrl), $statusCode, $response->getContent()), $statusCode, $response->getContent());


### PR DESCRIPTION
Large files(e.g. 2GB) are causing out of memory exception on File::openBinary. Response is redirected to a file by usin CURLOPT_FILE option instead of keeping it in the memory.