### PR TITLE
Ensure key names are type safe

### DIFF
--- a/src/SharePoint/File.php
+++ b/src/SharePoint/File.php
@@ -324,10 +324,10 @@ class File extends SecurableObject
     function setProperty($name, $value, $persistChanges = true)
     {
         parent::setProperty($name, $value, $persistChanges);
-        if ($name == "UniqueId") {
+        if ($name === "UniqueId") {
             $this->resourcePath = new ResourcePath("GetFileById(guid'{$value}')", new ResourcePath("Web"));
         } else {
-            if ($name == "ServerRelativeUrl") {
+            if ($name === "ServerRelativeUrl") {
                 $this->resourcePath = new ResourcePath("GetFileByServerRelativeUrl('{$value}')", new ResourcePath("Web"));
             }
         }


### PR DESCRIPTION
Issue:

Today when uploading a document I found there I was getting an error thrown:
`ErrorException: Array to string conversion in /var/www/html/vendor/vgrem/php-spo/src/SharePoint/File.php:328`

Digging into the json response it looks when it tries to parse the array of responses it coerced the zero of the index to the string and returned a truthy match,

e.g. response returned was:

```
^ array:1 [
  "d" => array:1 [
    "results" => array:1 [
      0 => array:32 [
```

So when mapping over the array from results, `0 == 'UniqueId'` will equal true.

This patch prevents that from happening. Not sure if I'm fixing the symptom rather than the problem of an array response.