### PR TITLE
Federated STS URL parsing fix

### DIFF
--- a/src/Runtime/Auth/SamlTokenProvider.php
+++ b/src/Runtime/Auth/SamlTokenProvider.php
@@ -195,8 +195,8 @@ class SamlTokenProvider extends BaseTokenProvider
             $xml = new DOMDocument();
             $xml->loadXML($response);
             $xpath = new DOMXPath($xml);
-            if ($xpath->query("//STSAuthURL")->length > 0) {
-                return $xpath->query("//STSAuthURL")->item(0);
+            if ($xpath->query("//AuthURL")->length > 0) {
+                return $xpath->query("//AuthURL")->item(0);
             }
         }
         return null;

--- a/src/Runtime/Http/Requests.php
+++ b/src/Runtime/Http/Requests.php
@@ -134,7 +134,7 @@ class Requests
             $opt = $options->Method === HttpMethod::Get ? CURLOPT_FILE : CURLOPT_INFILE;
             curl_setopt($ch, $opt, $options->StreamHandle);
         }
-        $options->ensureHeader("Content-Length",strlen($options->Data));
+        $options->ensureHeader("Content-Length", strlen($options->Data !== null ? $options->Data : ''));
         //custom HTTP headers
         if($options->Headers)
             curl_setopt($ch, CURLOPT_HTTPHEADER, $options->getRawHeaders());


### PR DESCRIPTION
I ran into an issue trying to use the federated Sharepoint Online authentication, so I ran the requests in Postman manually and found an inconsistency. The following is a redacted JSON response I got:
```
{
    "State": 3,
    "UserState": 2,
    "Login": "{user}@{company}.com",
    "NameSpaceType": "Federated",
    "DomainName": "{company}.com",
    "FederationGlobalVersion": -1,
    "AuthURL": "https://adfs.{company}.com/adfs/ls/?username={user}%40{company}.com&wa=wsignin1.0&wtrealm=urn%3afederation%3aMicrosoftOnline&wctx=",
    "FederationBrandName": "{company name}",
    "CloudInstanceName": "microsoftonline.com",
    "CloudInstanceIssuerUri": "urn:federation:MicrosoftOnline"
}
```
, whereas the code is trying to parse a "STSAuthURL" field.