### PR TITLE
Added new exception for outdated client credentials

### DIFF
--- a/src/Runtime/Auth/AuthenticationContext.php
+++ b/src/Runtime/Auth/AuthenticationContext.php
@@ -135,6 +135,11 @@ class AuthenticationContext implements IAuthenticationContext
      */
     protected function ensureAuthorizationHeader(RequestOptions $options)
     {
+        if (isset($this->accessToken['error']))
+        {
+            throw new Exception($this->accessToken['error_description']);
+        }
+
         $value = $this->accessToken['token_type'] . ' ' . $this->accessToken['access_token'];
         $options->ensureHeader('Authorization', $value);
     }


### PR DESCRIPTION
Added new exception which is thrown when using outdated client credentials.

Right now when outdated client credentials are used, an `Undefined array key "token_type"` error is thrown. This isn't very clear. With the added exception the real error is revealed. 