### PR TITLE
Fixes an issue that I introduced when validating an incoming response.

### DIFF
--- a/src/Runtime/Http/Response.php
+++ b/src/Runtime/Http/Response.php
@@ -47,8 +47,8 @@ class Response
                 if (array_key_exists('X-MSDAVEXT_Error', $headers)) {
                     $this->Content = urldecode($headers['X-MSDAVEXT_Error']);
                 }
+                throw new RequestException($this->Content,$this->StatusCode);
             }
-            throw new RequestException($this->Content,$this->StatusCode);
         }
     }
 


### PR DESCRIPTION
Not all 4xx responses need to throw an exception. Specifically the first connection, as this request/response provides this library with information to use during the authentication/authorization process.

This will still capture the Microsoft specific header, and throw an exception when it's present.