### PR TITLE
Remove minimum-stability from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
         }
     ],
     "license": "MIT",
-    "minimum-stability": "dev",
     "require": {
         "php": ">=5.5",
         "ext-curl": "*",


### PR DESCRIPTION
We do not need it since we do not have any non-dev-dependencies, and phpunit can be the latest stable version.

Resolves: https://github.com/vgrem/phpSPO/issues/123