### PR TITLE
Deprecation fixes for PHP 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "license": "MIT",
     "require": {
-        "php": ">=5.5",
+        "php": ">=7.1",
         "ext-curl": "*",
         "ext-json": "*",
         "ext-simplexml": "*",

--- a/src/Runtime/Auth/AuthenticationContext.php
+++ b/src/Runtime/Auth/AuthenticationContext.php
@@ -151,7 +151,7 @@ class AuthenticationContext implements IAuthenticationContext
      */
     protected function ensureAuthenticationCookie(RequestOptions $options)
     {
-        $headerVal = http_build_query($this->authCookies,null, "; ");
+        $headerVal = http_build_query($this->authCookies, '', "; ");
         $options->ensureHeader('Cookie', urldecode($headerVal));
     }
 

--- a/src/Runtime/ClientObjectCollection.php
+++ b/src/Runtime/ClientObjectCollection.php
@@ -281,10 +281,10 @@ class ClientObjectCollection extends ClientObject implements IteratorAggregate, 
 
 
     /**
-     * @return Generator|Traversable
+     * @return Traversable
      * @throws Exception
      */
-    public function getIterator()
+    public function getIterator(): Traversable
     {
         /** @var ClientObject $item */
         foreach ($this->data as $index => $item) {
@@ -321,11 +321,12 @@ class ClientObjectCollection extends ClientObject implements IteratorAggregate, 
      * @return boolean
      * @abstracting ArrayAccess
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->data[$offset]);
     }
 
+    #[\ReturnTypeWillChange]
     /**
      * Returns the value at specified offset
      *
@@ -348,7 +349,7 @@ class ClientObjectCollection extends ClientObject implements IteratorAggregate, 
      * @access public
      * @abstracting ArrayAccess
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->data[] = $value;
@@ -364,7 +365,7 @@ class ClientObjectCollection extends ClientObject implements IteratorAggregate, 
      * @access public
      * @abstracting ArrayAccess
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         if ($this->offsetExists($offset)) {
             unset($this->data[$offset]);

--- a/src/Runtime/Http/Requests.php
+++ b/src/Runtime/Http/Requests.php
@@ -134,7 +134,7 @@ class Requests
             $opt = $options->Method === HttpMethod::Get ? CURLOPT_FILE : CURLOPT_INFILE;
             curl_setopt($ch, $opt, $options->StreamHandle);
         }
-        $options->ensureHeader("Content-Length",strlen($options->Data));
+        $options->ensureHeader("Content-Length",strlen((string) $options->Data));
         //custom HTTP headers
         if($options->Headers)
             curl_setopt($ch, CURLOPT_HTTPHEADER, $options->getRawHeaders());


### PR DESCRIPTION
The library itself works with PHP8, but deprecation notices are thrown.

The commits here get rid of those while keeping compatibility with PHP 7.1+ (compat with PHP 5 is not possible anymore).

Related: https://github.com/vgrem/phpSPO/issues/293