### PR TITLE
Http Response improvements

### DIFF
--- a/src/Runtime/Http/Requests.php
+++ b/src/Runtime/Http/Requests.php
@@ -13,21 +13,19 @@ class Requests
 
     /**
      * @param RequestOptions $options
-     * @param array $headers
      * @return Response
      * @throws RequestException
      */
-	public static function execute(RequestOptions $options, &$headers = array())
+	public static function execute(RequestOptions $options)
 	{
-		$ch = Requests::init($options);
-        $response = curl_exec($ch);
-        $headers["HttpCode"] = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-        $headers["ContentType"] = curl_getinfo($ch, CURLINFO_CONTENT_TYPE);
-        if ($response === false) {
-            throw new RequestException(curl_error($ch), curl_errno($ch));
-        }
-        curl_close($ch);
-		return new Response($response,$headers);
+            $ch = Requests::init($options);
+            $response = curl_exec($ch);
+            $curlInfo = curl_getinfo($ch);
+            if ($response === false) {
+                throw new RequestException(curl_error($ch), curl_errno($ch));
+            }
+            curl_close($ch);
+            return new Response($response, $curlInfo, $options);
 	}
 
 

--- a/src/Runtime/Http/Response.php
+++ b/src/Runtime/Http/Response.php
@@ -6,32 +6,78 @@ namespace Office365\Runtime\Http;
 
 class Response
 {
-    public function __construct($content, $headers)
+    public function __construct($content, $curlInfo, RequestOptions $requestOptions)
     {
         $this->Content = $content;
-        $this->StatusCode = $headers['HttpCode'];
+        $this->CurlInfo = $curlInfo;
+        $this->RequestOptions = $requestOptions;
+
         // validate the individual responses,
         // so we can catch an instance where there is an unauthorized response.
         $this->validate();
     }
 
+    /**
+     * returns a Array including all response headers of
+     * this request. when RequestOptions::IncludeHeaders was not
+     * set to true this will be empty.
+     * @return Array
+     */
     public function getHeaders()
     {
         if (!empty($this->Headers)) {
             return $this->Headers;
         }
-        $lines = array_map(function ($line) {
-            return $line;
-        }, explode("\r\n", $this->getContent()));
-        $this->Headers = [];
 
+        // Headers where not included into the response.
+        if (!$this->RequestOptions->IncludeHeaders) {
+            return [];
+        }
+
+        $endOfHeaderPos = strpos($this->Content, "\r\n\r\n");
+
+        $lines = [];
+        if ($endOfHeaderPos === false) {
+            $lines = explode("\r\n", $this->Content);
+        } else {
+            $lines = explode("\r\n", substr($this->Content, 0, $endOfHeaderPos));
+        }
+
+        $this->Headers = [];
         foreach ($lines as $line){
-            if($line != ""){
-                list($k, $v) = preg_split("/[ :]/", $line,2);
-                $this->Headers[$k] = $v;
+            if($line){
+                list($k, $v) = preg_split("/[ :]/", $line, 2);
+                $this->Headers[strtolower(trim($k))] = trim($v);
             }
         }
         return $this->Headers;
+    }
+
+    /**
+     * Returns a specific response header or null when he was not set.
+     * @param String $key
+     * @return String|null
+     */
+    public function getHeader($key) {
+        $headers = $this->getHeaders();
+        return $headers[strtolower($key)] ?? null;
+    }
+
+    /**
+     * Returns the body of the response without the header part.
+     * @return String
+     */
+    public function getBody() {
+        if ($this->RequestOptions->IncludeHeaders) {
+
+            // return body without header
+            $endOfHeaderPos = strpos($this->getContent(), "\r\n\r\n");
+            if ($endOfHeaderPos !== false) {
+                return substr($this->getContent(), $endOfHeaderPos + 4);
+            }
+        }
+
+        return $this->getContent();
     }
 
 
@@ -39,34 +85,74 @@ class Response
      *
      * @throws RequestException
      */
-    public function validate(){
-        if ($this->StatusCode >= 400) {
-            $headers = $this->getHeaders();
-            $content = $this->Content;
-            if (array_key_exists('Content-Length', $headers) && trim($headers['Content-Length']) == '0') {
-                if (array_key_exists('X-MSDAVEXT_Error', $headers)) {
-                    $this->Content = urldecode($headers['X-MSDAVEXT_Error']);
+    public function validate()
+    {
+        if ($this->getStatusCode() >= 400) {
+            if ($this->getHeader('Content-Length') !== null && (int)$this->getHeader('Content-Length') === 0) {
+                if ($this->getHeader('X-MSDAVEXT_Error')) {
+                    $this->Content = urldecode($this->getHeader('X-MSDAVEXT_Error'));
                 }
-                throw new RequestException($this->Content,$this->StatusCode);
+                throw new RequestException($this->Content, $this->getStatusCode());
             }
         }
     }
 
-    public function getStatusCode()
+    /**
+     * returns the Content-Type of the response or null when not provided.
+     * @return String|null
+     */
+    public function getContentType()
     {
-        return $this->StatusCode;
+        return $this->CurlInfo['content_type'] ?? null;
     }
 
-    public function getContent(){
+    /**
+     * returns the array of curl_getinfo.
+     * Check https://www.php.net/manual/function.curl-getinfo.php for the available keys.
+     * @return Array
+     */
+    public function getCurlInfo()
+    {
+        return $this->CurlInfo ?? array();
+    }
+
+    /**
+     * returns the HTTP status code of the response
+     * @return Int|null
+     */
+    public function getStatusCode()
+    {
+        return isset($this->CurlInfo['http_code']) ? (int)$this->CurlInfo['http_code'] : null;
+    }
+
+    /**
+     * returns the RequestOptions object which was used to perform the request.
+     * @return RequestOptions
+     */
+    public function getRequestOptions()
+    {
+        return $this->RequestOptions;
+    }
+
+    /**
+     * returns the content of the response. When IncludeHeaders was set to true
+     * this will contain header and body.
+     * @return String
+     */
+    public function getContent()
+    {
         return $this->Content;
     }
 
+    /**
+     * @var RequestOptions
+     */
+    protected $RequestOptions;
 
     /**
-     * @var integer
+     * @var Array
      */
-    protected $StatusCode;
-
+    protected $CurlInfo;
 
     /**
      * @var mixed


### PR DESCRIPTION
Some improvements on the Http Response Object which make it easier to access headers and body separately.

Office365\Runtime\Http\Requests
    - static function `execute`: Remove never used parameter `$headers`, as it was never used and not usable.

Office365\Runtime\Http\Response
    - the function `getHeaders` returns only the headers and ignores the body when the request was made with `IncludeHeaders = true`
    - new function `getBody` which returns only the body part of the request
    - new function `getContentType` which returns the content type of the response
    - new function `getCurlInfo` which returns the curl info array
    - new function `getRequestOptions` which returns the RequestOptions object which was used to create the request