### PR TITLE
Fix issue w tiny upload session not being finalized.

### DIFF
--- a/src/SharePoint/UploadSession.php
+++ b/src/SharePoint/UploadSession.php
@@ -44,12 +44,13 @@ class UploadSession
             if ($firstChunk) {
                 $uploadFile->startUpload($this->uploadSessionId, $buffer);
                 $firstChunk = false;
-            } elseif ($fileSize == $bytesRead) {
-                $this->targetFile = $uploadFile->finishUpload($this->uploadSessionId,$offset, $buffer);
             } else {
                 $uploadFile->continueUpload($this->uploadSessionId,$offset, $buffer);
             }
             $offset = $bytesRead;
+            if ($fileSize == $bytesRead) {
+                $this->targetFile = $uploadFile->finishUpload($this->uploadSessionId,$offset, '');
+            }
         }
         fclose($handle);
 


### PR DESCRIPTION
Fixes an issue in upload sessions with data sizes <= buffer size where the File::finishUpload method is not called to commit the file. This fix ensures the method is called at the end of the upload.