### PR TITLE
Fix: Don't try to retrieve next set of items when using an iterator, if no next items are expected to exist

### DIFF
--- a/src/Runtime/ClientObjectCollection.php
+++ b/src/Runtime/ClientObjectCollection.php
@@ -369,8 +369,8 @@ class ClientObjectCollection extends ClientObject implements IteratorAggregate, 
         }
 
         if($this->pagedMode){
-            $nextItems = $this->getNext()->executeQuery();
             if($this->hasNext()){
+                $nextItems = $this->getNext()->executeQuery();
                 foreach ($nextItems as $item){
                     yield $item;
                 }

--- a/tests/sharepoint/ListItemTest.php
+++ b/tests/sharepoint/ListItemTest.php
@@ -38,6 +38,23 @@ class ListItemTest extends SharePointTestCase
         $this->assertEquals($itemsCount, $items->getCount());
     }
 
+    public function testIterator()
+    {
+        // Test that list items can be iterated over without crashing
+        // First, test a simple get with no paging
+        foreach (self::$targetList->getItems()->get()->executeQuery() as $item) {
+            $this->assertNotEmpty($item);
+        }
+        // Now test with explicit paging
+        foreach (self::$targetList->getItems()->get()->paged(1)->executeQuery() as $item) {
+            $this->assertNotEmpty($item);
+        }
+        // Now test with implicit paging via getAll()
+        foreach (self::$targetList->getItems()->getAll()->executeQuery() as $item) {
+            $this->assertNotEmpty($item);
+        }
+    }
+
 
     public function testCreateFolderInList(){
         //ensure Folder creation is enabled for a List


### PR DESCRIPTION
We use this library to retrieve Sharepoint lists and came across a crash when using the `getAll()` method of `ClientObjectCollection`. 

## Symptoms

When using `foreach` on a `ListItemCollection`, the following error occurs:

```
In Requests.php line 34:
                                                 
  [Office365\Runtime\Http\RequestException (3)]  
                                                 

Exception trace:
  at /var/www/api/vendor/vgrem/php-spo/src/Runtime/Http/Requests.php:34
 Office365\Runtime\Http\Requests::execute() at /var/www/api/vendor/vgrem/php-spo/src/Runtime/ClientRequest.php:101
 Office365\Runtime\ClientRequest->executeQueryDirect() at /var/www/api/vendor/vgrem/php-spo/src/Runtime/OData/ODataRequest.php:128
 Office365\Runtime\OData\ODataRequest->executeQueryDirect() at /var/www/api/vendor/vgrem/php-spo/src/Runtime/ClientRequest.php:83
 Office365\Runtime\ClientRequest->executeQuery() at /var/www/api/vendor/vgrem/php-spo/src/Runtime/ClientRuntimeContext.php:81
 Office365\Runtime\ClientRuntimeContext->executeQuery() at /var/www/api/vendor/vgrem/php-spo/src/Runtime/ClientObject.php:99
 Office365\Runtime\ClientObject->executeQuery() at /var/www/api/vendor/vgrem/php-spo/src/Runtime/ClientObjectCollection.php:372
 Office365\Runtime\ClientObjectCollection->getIterator() at /var/www/api/app/Integration/Services/Sharepoint/ListFileIntegration.php:67
...
```

## Cause

I believe this is because we're using a `foreach` which is causing `getIterator` to be called and that is trying to retrieve the next set of items *before* it checks whether there are any more items to retrieve.

## Fix

Simple - I just moved the line which retrieves the items inside the conditional which checks whether items are expected to exist.

## Tests

I'm happy to add a test somewhere if someone can give me a pointer to the relevant test case.
