### PR TITLE
Fix "A type named '.ListItemFormUpdateValue' could not be resolved" error

### DIFF
--- a/src/Runtime/ServerTypeInfo.php
+++ b/src/Runtime/ServerTypeInfo.php
@@ -6,7 +6,6 @@ use Exception;
 use Office365\Complex;
 use Office365\GraphServiceClient;
 use Office365\SharePoint\ClientContext;
-use Office365\SharePoint\ListItemFormUpdateValue;
 
 class ServerTypeInfo
 {
@@ -74,9 +73,6 @@ class ServerTypeInfo
                 if(is_null($namespace)) $namespace = "microsoft.graph";
                 $typeName = lcfirst($typeName);
             }
-        }
-        elseif($type instanceof ListItemFormUpdateValue) {
-            if(is_null($namespace)) $namespace = "SP";
         }
         elseif($type instanceof Complex){
             if(is_null($namespace)) $namespace = "microsoft.graph";

--- a/src/Runtime/ServerTypeInfo.php
+++ b/src/Runtime/ServerTypeInfo.php
@@ -6,6 +6,7 @@ use Exception;
 use Office365\Complex;
 use Office365\GraphServiceClient;
 use Office365\SharePoint\ClientContext;
+use Office365\SharePoint\ListItemFormUpdateValue;
 
 class ServerTypeInfo
 {
@@ -73,6 +74,9 @@ class ServerTypeInfo
                 if(is_null($namespace)) $namespace = "microsoft.graph";
                 $typeName = lcfirst($typeName);
             }
+        }
+        elseif($type instanceof ListItemFormUpdateValue) {
+            if(is_null($namespace)) $namespace = "SP";
         }
         elseif($type instanceof Complex){
             if(is_null($namespace)) $namespace = "microsoft.graph";

--- a/src/SharePoint/ListItemFormUpdateValue.php
+++ b/src/SharePoint/ListItemFormUpdateValue.php
@@ -6,6 +6,8 @@
 namespace Office365\SharePoint;
 
 use Office365\Runtime\ClientValue;
+use Office365\Runtime\ServerTypeInfo;
+
 /**
  * Specifies 
  * the properties of a list itemfield (2) 
@@ -30,6 +32,12 @@ class ListItemFormUpdateValue extends ClientValue
             $json['FieldValue'] = "[{'Key':'$value->LookupValue'}]";
         }
         return $json;
+    }
+
+
+    public function getServerTypeInfo()
+    {
+        return new ServerTypeInfo("SP", "ListItemFormUpdateValue");
     }
 
     /**


### PR DESCRIPTION
Hello!

I recently had to update metadata on Sharepoint using the `ValidateUpdateListItem` method:
```php
$sharepointClient->getWeb()
    ->getLists()
    ->getById($listId)
    ->getItemById($itemId)
    ->validateUpdateListItem($metadata);
```

Except it never worked because Sharepoint would return this error message:
> A type named '.ListItemFormUpdateValue' could not be resolved

The error message refers to the `__metadata` field sent to Sharepoint:
```json
{
    "formValues": [
        {
            "FieldName":"User",
            "FieldValue":"[{'Key':'i:0#.f|membership|xxx'}]",
            "__metadata":{"type":".ListItemFormUpdateValue"}
        }
    ],
 }
```

---
`__metadata` is determined by `ODataRequest` during the `normalizePayload` method. `ListItemFormUpdateValue` being a `ClientValue`, it goes through a call to `ensureAnnotation` which is responsible of adding the `__metadata` value.
The `__metadata` value is set to whatever `$type->getServerTypeInfo()` returns. Which in our case, `$type` is of type `ListItemFormUpdateValue`.

To understand where `ListItemFormUpdateValue` comes from, let's look at `validateUpdateListItem`:
The first thing that `validateUpdateListItem` does is converting the fields into a ListItemFormUpdateValue class:
```php
$normalizedFormValues = array_map(function ($k, $v) {
    return new ListItemFormUpdateValue($k, $v);
}, array_keys($formValues), array_values($formValues));
```
So, it's an automated procedure whenever one wants to use `validateUpdateListItem`.

Now, back to why the metadata is not valid according to Sharepoint, the expected value should be `SP.ListItemFormUpdateValue`.
Looking through how `getServerTypeInfo` works, it resolves the type by looking at what class we are looking at. There's a branch handling `ClientObject` types, and another branch for `Complex`. The issue is, `ListItemFormUpdateValue` is a `ClientValue`, which is not handled in this method.

My solution to this is simple: We just now handle `ListItemFormUpdateValue` specifically, and set the `SP` namespace in that case, if the namespace is not already set to something else (mimicking the same behavior as the other branches).
Since I am unsure if all classes that inherits `ClientValue` have a valid `SP` namespace, I just focused on the only one I was certain it needed it.