### PR TITLE
Fix php8.4 deprecated notices

### DIFF
--- a/src/Directory/Users/UserCollection.php
+++ b/src/Directory/Users/UserCollection.php
@@ -11,7 +11,7 @@ use Office365\Runtime\ResourcePath;
 class UserCollection extends EntityCollection
 {
 
-    public function __construct(ClientRuntimeContext $ctx, ResourcePath $resourcePath = null)
+    public function __construct(ClientRuntimeContext $ctx, ?ResourcePath $resourcePath = null)
     {
         parent::__construct($ctx, $resourcePath, User::class);
     }

--- a/src/Entity.php
+++ b/src/Entity.php
@@ -18,7 +18,7 @@ use Office365\Runtime\ResourcePath;
 class Entity extends ClientObject
 {
 
-    public function __construct(ClientRuntimeContext $ctx, ResourcePath $resourcePath = null, $namespace = null)
+    public function __construct(ClientRuntimeContext $ctx, ?ResourcePath $resourcePath = null, $namespace = null)
     {
         parent::__construct($ctx, $resourcePath, null, $namespace);
     }

--- a/src/EntityCollection.php
+++ b/src/EntityCollection.php
@@ -19,7 +19,7 @@ class EntityCollection extends ClientObjectCollection
      * @param ResourcePath|null $resourcePath
      * @param null $itemTypeName
      */
-    public function __construct(ClientRuntimeContext $ctx, ResourcePath $resourcePath = null, $itemTypeName = null)
+    public function __construct(ClientRuntimeContext $ctx, ?ResourcePath $resourcePath = null, $itemTypeName = null)
     {
         parent::__construct($ctx, $resourcePath, $itemTypeName);
     }

--- a/src/OneDrive/DriveItems/DriveItemCollection.php
+++ b/src/OneDrive/DriveItems/DriveItemCollection.php
@@ -18,7 +18,7 @@ use stdClass;
 class DriveItemCollection extends EntityCollection
 {
 
-    public function __construct(ClientRuntimeContext $ctx, ResourcePath $resourcePath = null)
+    public function __construct(ClientRuntimeContext $ctx, ?ResourcePath $resourcePath = null)
     {
         parent::__construct($ctx, $resourcePath, DriveItem::class);
     }

--- a/src/OneDrive/Drives/DriveCollection.php
+++ b/src/OneDrive/Drives/DriveCollection.php
@@ -12,7 +12,7 @@ use Office365\Runtime\ResourcePath;
 class DriveCollection extends EntityCollection
 {
 
-    public function __construct(ClientRuntimeContext $ctx, ResourcePath $resourcePath = null)
+    public function __construct(ClientRuntimeContext $ctx, ?ResourcePath $resourcePath = null)
     {
         parent::__construct($ctx, $resourcePath, Drive::class);
     }

--- a/src/OneDrive/ListItems/ListItemCollection.php
+++ b/src/OneDrive/ListItems/ListItemCollection.php
@@ -11,7 +11,7 @@ use Office365\Runtime\ResourcePath;
 class ListItemCollection extends EntityCollection
 {
 
-    public function __construct(ClientRuntimeContext $ctx, ResourcePath $resourcePath = null)
+    public function __construct(ClientRuntimeContext $ctx, ?ResourcePath $resourcePath = null)
     {
         parent::__construct($ctx, $resourcePath, ListItem::class);
     }

--- a/src/OneDrive/PermissionCollection.php
+++ b/src/OneDrive/PermissionCollection.php
@@ -11,7 +11,7 @@ use Office365\Runtime\ResourcePath;
 class PermissionCollection extends EntityCollection
 {
 
-    public function __construct(ClientRuntimeContext $ctx, ResourcePath $resourcePath = null)
+    public function __construct(ClientRuntimeContext $ctx, ?ResourcePath $resourcePath = null)
     {
         parent::__construct($ctx, $resourcePath, Permission::class);
     }

--- a/src/OneNote/Pages/OnenotePageCollection.php
+++ b/src/OneNote/Pages/OnenotePageCollection.php
@@ -11,7 +11,7 @@ use Office365\Runtime\ResourcePath;
 
 class OnenotePageCollection extends EntityCollection
 {
-    public function __construct(ClientRuntimeContext $ctx, ResourcePath $resourcePath = null)
+    public function __construct(ClientRuntimeContext $ctx, ?ResourcePath $resourcePath = null)
     {
         parent::__construct($ctx, $resourcePath, OnenotePage::class);
     }

--- a/src/Outlook/Recipient.php
+++ b/src/Outlook/Recipient.php
@@ -9,7 +9,7 @@ use Office365\Complex;
 
 class Recipient extends Complex
 {
-    function __construct(EmailAddress $emailAddress=null)
+    function __construct(?EmailAddress $emailAddress=null)
     {
         $this->EmailAddress = $emailAddress;
         parent::__construct();

--- a/src/Runtime/ClientObject.php
+++ b/src/Runtime/ClientObject.php
@@ -58,8 +58,8 @@ class ClientObject
      * @param string|null $namespace
      */
     public function __construct(ClientRuntimeContext $ctx,
-                                ResourcePath $resourcePath = null,
-                                ODataQueryOptions $queryOptions = null,
+                                ?ResourcePath $resourcePath = null,
+                                ?ODataQueryOptions $queryOptions = null,
                                 $namespace=null)
     {
         $this->context = $ctx;

--- a/src/Runtime/ClientObjectCollection.php
+++ b/src/Runtime/ClientObjectCollection.php
@@ -91,7 +91,7 @@ class ClientObjectCollection extends ClientObject implements IteratorAggregate, 
      * @param ResourcePath $resourcePath
      * @param string $itemTypeName
      */
-    public function __construct(ClientRuntimeContext $ctx,ResourcePath $resourcePath = null,$itemTypeName=null)
+    public function __construct(ClientRuntimeContext $ctx, ?ResourcePath $resourcePath = null, $itemTypeName=null)
     {
         parent::__construct($ctx, $resourcePath);
         $this->data = array();

--- a/src/Runtime/ClientRuntimeContext.php
+++ b/src/Runtime/ClientRuntimeContext.php
@@ -63,7 +63,7 @@ abstract class ClientRuntimeContext
      * @param string[] $includeProperties
      * @return ClientRuntimeContext
      */
-    public function load(ClientObject $clientObject, array $includeProperties = null)
+    public function load(ClientObject $clientObject, ?array $includeProperties = null)
     {
         $qry = new ReadEntityQuery($clientObject,$includeProperties);
         $this->addQueryAndResultObject($qry, $clientObject);

--- a/src/Runtime/OData/ODataReader.php
+++ b/src/Runtime/OData/ODataReader.php
@@ -14,7 +14,7 @@ abstract class ODataReader
     {
         $model = new ODataModel($options);
         $model->onTypeResolved(function ($typeSchema){
-            echo "${typeSchema['name']} type resolved." .  PHP_EOL;
+            echo "{$typeSchema['name']} type resolved." .  PHP_EOL;
         });
         $edmx = file_get_contents($options['metadataPath']);
         $this->parseEdmx($edmx, $model);

--- a/src/Runtime/OData/V3/ODataV3Reader.php
+++ b/src/Runtime/OData/V3/ODataV3Reader.php
@@ -11,7 +11,7 @@ use SimpleXMLIterator;
 class ODataV3Reader extends ODataReader
 {
 
-    function parseEdmx($edmx, $model, SimpleXMLIterator &$parentNode = null, SimpleXMLIterator &$prevNode = null, $prevValue=null)
+    function parseEdmx($edmx, $model, ?SimpleXMLIterator &$parentNode = null, ?SimpleXMLIterator &$prevNode = null, $prevValue=null)
     {
         if (is_null($parentNode)) {
             $parentNode = new SimpleXMLIterator($edmx);

--- a/src/Runtime/OData/V4/ODataV4Reader.php
+++ b/src/Runtime/OData/V4/ODataV4Reader.php
@@ -10,7 +10,7 @@ use SimpleXMLIterator;
 class ODataV4Reader extends ODataReader
 {
 
-    function parseEdmx($edmx, $model, SimpleXMLIterator &$parentNode = null, SimpleXMLIterator &$prevNode = null, $prevValue=null)
+    function parseEdmx($edmx, $model, ?SimpleXMLIterator &$parentNode = null, ?SimpleXMLIterator &$prevNode = null, $prevValue=null)
     {
         if (is_null($parentNode)) {
             $parentNode = new SimpleXMLIterator($edmx);

--- a/src/Runtime/Paths/EntityPath.php
+++ b/src/Runtime/Paths/EntityPath.php
@@ -14,7 +14,7 @@ class EntityPath extends ResourcePath
      * @param string|null $key
      * @param ResourcePath|null $parent
      */
-    public function __construct($key = null, ResourcePath $parent = null)
+    public function __construct($key = null, ?ResourcePath $parent = null)
     {
         parent::__construct($key, $parent);
     }

--- a/src/Runtime/Paths/ResourcePathUrl.php
+++ b/src/Runtime/Paths/ResourcePathUrl.php
@@ -10,7 +10,7 @@ use Office365\Runtime\ResourcePath;
  */
 class ResourcePathUrl extends ResourcePath
 {
-    public function __construct($url, ResourcePath $parent = null)
+    public function __construct($url, ?ResourcePath $parent = null)
     {
         parent::__construct($url, $parent);
     }

--- a/src/Runtime/Paths/ServiceOperationPath.php
+++ b/src/Runtime/Paths/ServiceOperationPath.php
@@ -20,7 +20,7 @@ class ServiceOperationPath extends ResourcePath implements ICSOMCallable
      * @param array|ClientObject|ClientValue $methodParameters
      * @param ResourcePath|null $parent
      */
-    public function __construct($methodName=null, $methodParameters = null,ResourcePath $parent=null)
+    public function __construct($methodName=null, $methodParameters = null, ?ResourcePath $parent=null)
     {
         parent::__construct($this->buildSegment($methodName,$methodParameters), $parent);
         $this->methodName = $methodName;

--- a/src/Runtime/ResourcePath.php
+++ b/src/Runtime/ResourcePath.php
@@ -10,7 +10,7 @@ class ResourcePath
      * @param string $name
      * @param ResourcePath|null $parent
      */
-    public function __construct($name, ResourcePath $parent = null)
+    public function __construct($name, ?ResourcePath $parent = null)
     {
         $this->name = $name;
         $this->parent = $parent;

--- a/src/SharePoint/AttachmentCollection.php
+++ b/src/SharePoint/AttachmentCollection.php
@@ -16,7 +16,7 @@ class AttachmentCollection extends BaseEntityCollection
      * @param ResourcePath|null $resourcePath
      * @param ClientObject|null $parent
      */
-    public function __construct(ClientRuntimeContext $ctx, ResourcePath $resourcePath = null, ClientObject $parent = null)
+    public function __construct(ClientRuntimeContext $ctx, ?ResourcePath $resourcePath = null, ?ClientObject $parent = null)
     {
         parent::__construct($ctx, $resourcePath, Attachment::class, $parent);
     }

--- a/src/SharePoint/BaseEntity.php
+++ b/src/SharePoint/BaseEntity.php
@@ -19,8 +19,8 @@ class BaseEntity extends ClientObject
 {
 
     public function __construct(ClientRuntimeContext $ctx,
-                                ResourcePath $resourcePath = null,
-                                ODataQueryOptions $queryOptions = null)
+                                ?ResourcePath $resourcePath = null,
+                                ?ODataQueryOptions $queryOptions = null)
     {
         parent::__construct($ctx,$resourcePath,$queryOptions,"SP");
     }

--- a/src/SharePoint/BaseEntityCollection.php
+++ b/src/SharePoint/BaseEntityCollection.php
@@ -27,9 +27,9 @@ class BaseEntityCollection extends ClientObjectCollection
      * @param ClientObject|null $parent
      */
     public function __construct(ClientRuntimeContext $ctx,
-                                ResourcePath $resourcePath = null,
+                                ?ResourcePath $resourcePath = null,
                                 $itemTypeName = null,
-                                ClientObject $parent=null)
+                                ?ClientObject $parent=null)
     {
         parent::__construct($ctx, $resourcePath, $itemTypeName);
         $this->parent = $parent;

--- a/src/SharePoint/ChangeCollection.php
+++ b/src/SharePoint/ChangeCollection.php
@@ -9,7 +9,7 @@ use Office365\Runtime\ResourcePath;
 
 class ChangeCollection extends BaseEntityCollection
 {
-    public function __construct(ClientRuntimeContext $ctx, ResourcePath $resourcePath = null, ClientObject $parent = null)
+    public function __construct(ClientRuntimeContext $ctx, ?ResourcePath $resourcePath = null, ?ClientObject $parent = null)
     {
         parent::__construct($ctx, $resourcePath, Change::class, $parent);
     }

--- a/src/SharePoint/ClientContext.php
+++ b/src/SharePoint/ClientContext.php
@@ -94,7 +94,7 @@ class ClientContext extends ClientRuntimeContext
      * @param string $url Site or Web url
      * @param IAuthenticationContext $authCtx
      */
-    public function __construct($url, IAuthenticationContext $authCtx=null)
+    public function __construct($url, ?IAuthenticationContext $authCtx=null)
     {
         $this->baseUrl = $url;
         $this->getPendingRequest()->beforeExecuteRequest(function (RequestOptions $request) {

--- a/src/SharePoint/ContentTypeCollection.php
+++ b/src/SharePoint/ContentTypeCollection.php
@@ -17,7 +17,7 @@ class ContentTypeCollection extends BaseEntityCollection
      * @param ResourcePath|null $resourcePath
      * @param ClientObject|null $parent
      */
-    public function __construct(ClientRuntimeContext $ctx, ResourcePath $resourcePath = null, ClientObject $parent = null)
+    public function __construct(ClientRuntimeContext $ctx, ?ResourcePath $resourcePath = null, ?ClientObject $parent = null)
     {
         parent::__construct($ctx, $resourcePath, ContentType::class, $parent);
     }

--- a/src/SharePoint/FieldCollection.php
+++ b/src/SharePoint/FieldCollection.php
@@ -14,7 +14,7 @@ use Office365\Runtime\ResourcePath;
 class FieldCollection extends BaseEntityCollection
 {
 
-    public function __construct(ClientRuntimeContext $ctx, ResourcePath $resourcePath = null, ClientObject $parent = null)
+    public function __construct(ClientRuntimeContext $ctx, ?ResourcePath $resourcePath = null, ?ClientObject $parent = null)
     {
         parent::__construct($ctx, $resourcePath, Field::class, $parent);
     }

--- a/src/SharePoint/FileCollection.php
+++ b/src/SharePoint/FileCollection.php
@@ -15,7 +15,7 @@ use Office365\Runtime\ResourcePath;
 class FileCollection extends BaseEntityCollection
 {
 
-    public function __construct(ClientRuntimeContext $ctx, ResourcePath $resourcePath = null, ClientObject $parent = null)
+    public function __construct(ClientRuntimeContext $ctx, ?ResourcePath $resourcePath = null, ?ClientObject $parent = null)
     {
         parent::__construct($ctx, $resourcePath, File::class, $parent);
     }
@@ -81,7 +81,7 @@ class FileCollection extends BaseEntityCollection
      * @param callable|null $chunkUploaded
      * @return UploadSession
      */
-    public function createUploadSession($sourcePath, $targetFileName,callable $chunkUploaded=null){
+    public function createUploadSession($sourcePath, $targetFileName, ?callable $chunkUploaded=null){
 
         $session = new UploadSession();
         $session->buildQuery($this,$sourcePath,$targetFileName,$chunkUploaded);

--- a/src/SharePoint/FileVersionCollection.php
+++ b/src/SharePoint/FileVersionCollection.php
@@ -10,7 +10,7 @@ use Office365\Runtime\ResourcePath;
 
 class FileVersionCollection extends BaseEntityCollection
 {
-    public function __construct(ClientRuntimeContext $ctx, ResourcePath $resourcePath = null, ClientObject $parent = null)
+    public function __construct(ClientRuntimeContext $ctx, ?ResourcePath $resourcePath = null, ?ClientObject $parent = null)
     {
         parent::__construct($ctx, $resourcePath, FileVersion::class, $parent);
     }

--- a/src/SharePoint/FolderCollection.php
+++ b/src/SharePoint/FolderCollection.php
@@ -20,7 +20,7 @@ class FolderCollection extends BaseEntityCollection
      * @param ResourcePath|null $resourcePath
      * @param ClientObject|null $parent
      */
-    public function __construct(ClientRuntimeContext $ctx, ResourcePath $resourcePath = null, ClientObject $parent = null)
+    public function __construct(ClientRuntimeContext $ctx, ?ResourcePath $resourcePath = null, ?ClientObject $parent = null)
     {
         parent::__construct($ctx, $resourcePath, Folder::class, $parent);
     }

--- a/src/SharePoint/GroupCollection.php
+++ b/src/SharePoint/GroupCollection.php
@@ -23,7 +23,7 @@ class GroupCollection extends BaseEntityCollection
      * @param ResourcePath|null $resourcePath
      * @param ClientObject|null $parent
      */
-    public function __construct(ClientRuntimeContext $ctx, ResourcePath $resourcePath = null, ClientObject $parent = null)
+    public function __construct(ClientRuntimeContext $ctx, ?ResourcePath $resourcePath = null, ?ClientObject $parent = null)
     {
         parent::__construct($ctx, $resourcePath, Group::class, $parent);
     }

--- a/src/SharePoint/Internal/Paths/FileContentPath.php
+++ b/src/SharePoint/Internal/Paths/FileContentPath.php
@@ -11,7 +11,7 @@ class FileContentPath extends ResourcePath
     /***
      * @param ResourcePath|null $parent
      */
-    public function __construct(ResourcePath $parent = null)
+    public function __construct(?ResourcePath $parent = null)
     {
         parent::__construct("\$value", $parent);
     }

--- a/src/SharePoint/ListCollection.php
+++ b/src/SharePoint/ListCollection.php
@@ -14,7 +14,7 @@ use Office365\Runtime\ResourcePath;
 class ListCollection extends BaseEntityCollection
 {
 
-    public function __construct(ClientRuntimeContext $ctx, ResourcePath $resourcePath = null, ClientObject $parent = null)
+    public function __construct(ClientRuntimeContext $ctx, ?ResourcePath $resourcePath = null, ?ClientObject $parent = null)
     {
         parent::__construct($ctx, $resourcePath, SPList::class , $parent);
     }

--- a/src/SharePoint/ListItemCollection.php
+++ b/src/SharePoint/ListItemCollection.php
@@ -12,7 +12,7 @@ use Office365\Runtime\ResourcePath;
  */
 class ListItemCollection extends BaseEntityCollection
 {
-     public function __construct(ClientRuntimeContext $ctx, ResourcePath $resourcePath = null, ClientObject $parent = null)
+     public function __construct(ClientRuntimeContext $ctx, ?ResourcePath $resourcePath = null, ?ClientObject $parent = null)
      {
          parent::__construct($ctx, $resourcePath, ListItem::class, $parent);
      }

--- a/src/SharePoint/Publishing/SpotlightChannelCollection.php
+++ b/src/SharePoint/Publishing/SpotlightChannelCollection.php
@@ -10,7 +10,7 @@ use Office365\SharePoint\BaseEntityCollection;
 
 class SpotlightChannelCollection extends BaseEntityCollection
 {
-    public function __construct(ClientRuntimeContext $ctx, ResourcePath $resourcePath = null, ClientObject $parent = null)
+    public function __construct(ClientRuntimeContext $ctx, ?ResourcePath $resourcePath = null, ?ClientObject $parent = null)
     {
         parent::__construct($ctx, $resourcePath, SpotlightChannel::class, $parent);
     }

--- a/src/SharePoint/Publishing/VideoCollection.php
+++ b/src/SharePoint/Publishing/VideoCollection.php
@@ -12,7 +12,7 @@ use Office365\SharePoint\BaseEntityCollection;
 
 class VideoCollection extends BaseEntityCollection
 {
-    public function __construct(ClientRuntimeContext $ctx, ResourcePath $resourcePath = null, ClientObject $parent = null)
+    public function __construct(ClientRuntimeContext $ctx, ?ResourcePath $resourcePath = null, ?ClientObject $parent = null)
     {
         parent::__construct($ctx, $resourcePath, VideoItem::class, $parent);
     }

--- a/src/SharePoint/RecycleBinItemCollection.php
+++ b/src/SharePoint/RecycleBinItemCollection.php
@@ -14,7 +14,7 @@ use Office365\Runtime\ResourcePath;
  */
 class RecycleBinItemCollection extends BaseEntityCollection
 {
-    public function __construct(ClientRuntimeContext $ctx, ResourcePath $resourcePath = null, ClientObject $parent = null)
+    public function __construct(ClientRuntimeContext $ctx, ?ResourcePath $resourcePath = null, ?ClientObject $parent = null)
     {
         parent::__construct($ctx, $resourcePath, RecycleBinItem::class, $parent);
     }

--- a/src/SharePoint/RoleAssignmentCollection.php
+++ b/src/SharePoint/RoleAssignmentCollection.php
@@ -18,7 +18,7 @@ use Office365\Runtime\ResourcePath;
 class RoleAssignmentCollection extends BaseEntityCollection
 {
 
-    public function __construct(ClientRuntimeContext $ctx, ResourcePath $resourcePath = null, ClientObject $parent = null)
+    public function __construct(ClientRuntimeContext $ctx, ?ResourcePath $resourcePath = null, ?ClientObject $parent = null)
     {
         parent::__construct($ctx, $resourcePath, RoleAssignment::class, $parent);
     }

--- a/src/SharePoint/SPList.php
+++ b/src/SharePoint/SPList.php
@@ -60,7 +60,7 @@ class SPList extends SecurableObject
      * @param CamlQuery $camlQuery
      * @return ListItemCollection
      */
-    public function getItems(CamlQuery $camlQuery = null)
+    public function getItems(?CamlQuery $camlQuery = null)
     {
         $targetItems = new ListItemCollection($this->getContext(), new ResourcePath("items", $this->getResourcePath()));
         if (is_null($camlQuery)) {

--- a/src/SharePoint/Taxonomy/TaxonomyItemCollection.php
+++ b/src/SharePoint/Taxonomy/TaxonomyItemCollection.php
@@ -17,9 +17,9 @@ class TaxonomyItemCollection extends ClientObjectCollection
     private $parent;
 
     public function __construct(ClientRuntimeContext $ctx,
-                                ResourcePath $resourcePath = null,
+                                ?ResourcePath $resourcePath = null,
                                 $itemTypeName = null,
-                                TaxonomyItem $parent=null)
+                                ?TaxonomyItem $parent=null)
     {
         parent::__construct($ctx, $resourcePath, $itemTypeName);
         $this->parent = $parent;

--- a/src/SharePoint/UploadSession.php
+++ b/src/SharePoint/UploadSession.php
@@ -27,7 +27,7 @@ class UploadSession
      * @param callable $chunkUploaded
      * @param int $chunkSize
      */
-    function buildQuery($files, $sourcePath, $targetFileName,  callable $chunkUploaded=null,$chunkSize = 1048576){
+    function buildQuery($files, $sourcePath, $targetFileName, ?callable $chunkUploaded=null, $chunkSize = 1048576){
         $ctx= $files->getContext();
         $fileSize = filesize($sourcePath);
         $firstChunk = true;

--- a/src/SharePoint/UserCollection.php
+++ b/src/SharePoint/UserCollection.php
@@ -19,7 +19,7 @@ class UserCollection extends BaseEntityCollection
      * @param ResourcePath|null $resourcePath
      * @param ClientObject|null $parent
      */
-    public function __construct(ClientRuntimeContext $ctx, ResourcePath $resourcePath = null, ClientObject $parent = null)
+    public function __construct(ClientRuntimeContext $ctx, ?ResourcePath $resourcePath = null, ?ClientObject $parent = null)
     {
         parent::__construct($ctx, $resourcePath, User::class, $parent);
     }

--- a/src/SharePoint/UserCustomActionCollection.php
+++ b/src/SharePoint/UserCustomActionCollection.php
@@ -11,7 +11,7 @@ use Office365\Runtime\ResourcePath;
  */
 class UserCustomActionCollection extends BaseEntityCollection
 {
-    public function __construct(ClientRuntimeContext $ctx, ResourcePath $resourcePath = null, ClientObject $parent = null)
+    public function __construct(ClientRuntimeContext $ctx, ?ResourcePath $resourcePath = null, ?ClientObject $parent = null)
     {
         parent::__construct($ctx, $resourcePath, UserCustomAction::class, $parent);
     }

--- a/src/SharePoint/ViewCollection.php
+++ b/src/SharePoint/ViewCollection.php
@@ -11,7 +11,7 @@ use Office365\Runtime\ResourcePath;
 class ViewCollection extends BaseEntityCollection
 {
 
-    public function __construct(ClientRuntimeContext $ctx, ResourcePath $resourcePath = null, ClientObject $parent = null)
+    public function __construct(ClientRuntimeContext $ctx, ?ResourcePath $resourcePath = null, ?ClientObject $parent = null)
     {
         parent::__construct($ctx, $resourcePath, View::class, $parent);
     }

--- a/src/SharePoint/WebCollection.php
+++ b/src/SharePoint/WebCollection.php
@@ -14,7 +14,7 @@ class WebCollection extends BaseEntityCollection
 {
 
     public function __construct(ClientRuntimeContext $ctx,
-                                ResourcePath $resourcePath = null,
+                                ?ResourcePath $resourcePath = null,
                                 $parentWeb=Null)
     {
         parent::__construct($ctx, $resourcePath,Web::class,$parentWeb);

--- a/src/SharePoint/WebParts/WebPartDefinitionCollection.php
+++ b/src/SharePoint/WebParts/WebPartDefinitionCollection.php
@@ -12,7 +12,7 @@ use Office365\SharePoint\BaseEntityCollection;
 class WebPartDefinitionCollection extends BaseEntityCollection
 {
 
-    public function __construct(ClientRuntimeContext $ctx, ResourcePath $resourcePath = null, ClientObject $parent = null)
+    public function __construct(ClientRuntimeContext $ctx, ?ResourcePath $resourcePath = null, ?ClientObject $parent = null)
     {
         parent::__construct($ctx, $resourcePath, WebPartDefinition::class, $parent);
     }

--- a/src/SharePoint/WebTemplateCollection.php
+++ b/src/SharePoint/WebTemplateCollection.php
@@ -10,7 +10,7 @@ use Office365\Runtime\ResourcePath;
 
 class WebTemplateCollection extends BaseEntityCollection
 {
-    public function __construct(ClientRuntimeContext $ctx, ResourcePath $resourcePath = null, ClientObject $parent = null)
+    public function __construct(ClientRuntimeContext $ctx, ?ResourcePath $resourcePath = null, ?ClientObject $parent = null)
     {
         parent::__construct($ctx, $resourcePath, WebTemplate::class, $parent);
     }

--- a/src/Teams/TeamCollection.php
+++ b/src/Teams/TeamCollection.php
@@ -14,7 +14,7 @@ use Office365\Runtime\ResourcePath;
 
 class TeamCollection extends EntityCollection
 {
-    public function __construct(ClientRuntimeContext $ctx, ResourcePath $resourcePath = null)
+    public function __construct(ClientRuntimeContext $ctx, ?ResourcePath $resourcePath = null)
     {
         parent::__construct($ctx, $resourcePath, Team::class);
     }


### PR DESCRIPTION
Fixes

```
PHP Deprecated:  Office365\EntityCollection::__construct(): Implicitly marking parameter $resourcePath as nullable is deprecated, the explicit nullable type must be used instead in ./src/EntityCollection.php on line 22
PHP Deprecated:  Office365\OneDrive\DriveItems\DriveItemCollection::__construct(): Implicitly marking parameter $resourcePath as nullable is deprecated, the explicit nullable type must be used instead in ./src/OneDrive/DriveItems/DriveItemCollection.php on line 21
PHP Deprecated:  Office365\OneDrive\Drives\DriveCollection::__construct(): Implicitly marking parameter $resourcePath as nullable is deprecated, the explicit nullable type must be used instead in ./src/OneDrive/Drives/DriveCollection.php on line 15
PHP Deprecated:  Office365\OneDrive\ListItems\ListItemCollection::__construct(): Implicitly marking parameter $resourcePath as nullable is deprecated, the explicit nullable type must be used instead in ./src/OneDrive/ListItems/ListItemCollection.php on line 14
PHP Deprecated:  Office365\OneDrive\PermissionCollection::__construct(): Implicitly marking parameter $resourcePath as nullable is deprecated, the explicit nullable type must be used instead in ./src/OneDrive/PermissionCollection.php on line 14
PHP Deprecated:  Office365\Runtime\ClientRuntimeContext::load(): Implicitly marking parameter $includeProperties as nullable is deprecated, the explicit nullable type must be used instead in ./src/Runtime/ClientRuntimeContext.php on line 66
PHP Deprecated:  Office365\Runtime\Paths\ServiceOperationPath::__construct(): Implicitly marking parameter $parent as nullable is deprecated, the explicit nullable type must be used instead in ./src/Runtime/Paths/ServiceOperationPath.php on line 23
PHP Deprecated:  Office365\Runtime\Paths\ResourcePathUrl::__construct(): Implicitly marking parameter $parent as nullable is deprecated, the explicit nullable type must be used instead in ./src/Runtime/Paths/ResourcePathUrl.php on line 13
PHP Deprecated:  Office365\Runtime\Paths\EntityPath::__construct(): Implicitly marking parameter $parent as nullable is deprecated, the explicit nullable type must be used instead in ./src/Runtime/Paths/EntityPath.php on line 17
PHP Deprecated:  Office365\Runtime\ResourcePath::__construct(): Implicitly marking parameter $parent as nullable is deprecated, the explicit nullable type must be used instead in ./src/Runtime/ResourcePath.php on line 13
PHP Deprecated:  Office365\Runtime\ClientObjectCollection::__construct(): Implicitly marking parameter $resourcePath as nullable is deprecated, the explicit nullable type must be used instead in ./src/Runtime/ClientObjectCollection.php on line 94
PHP Deprecated:  Using ${var} in strings is deprecated, use {$var} instead in ./src/Runtime/OData/ODataReader.php on line 17
PHP Deprecated:  Office365\Runtime\OData\V4\ODataV4Reader::parseEdmx(): Implicitly marking parameter $parentNode as nullable is deprecated, the explicit nullable type must be used instead in ./src/Runtime/OData/V4/ODataV4Reader.php on line 13
PHP Deprecated:  Office365\Runtime\OData\V4\ODataV4Reader::parseEdmx(): Implicitly marking parameter $prevNode as nullable is deprecated, the explicit nullable type must be used instead in ./src/Runtime/OData/V4/ODataV4Reader.php on line 13
PHP Deprecated:  Office365\Runtime\OData\V3\ODataV3Reader::parseEdmx(): Implicitly marking parameter $parentNode as nullable is deprecated, the explicit nullable type must be used instead in ./src/Runtime/OData/V3/ODataV3Reader.php on line 14
PHP Deprecated:  Office365\Runtime\OData\V3\ODataV3Reader::parseEdmx(): Implicitly marking parameter $prevNode as nullable is deprecated, the explicit nullable type must be used instead in ./src/Runtime/OData/V3/ODataV3Reader.php on line 14
PHP Deprecated:  Office365\Runtime\ClientObject::__construct(): Implicitly marking parameter $resourcePath as nullable is deprecated, the explicit nullable type must be used instead in ./src/Runtime/ClientObject.php on line 60
PHP Deprecated:  Office365\Runtime\ClientObject::__construct(): Implicitly marking parameter $queryOptions as nullable is deprecated, the explicit nullable type must be used instead in ./src/Runtime/ClientObject.php on line 60
PHP Deprecated:  Office365\Directory\Users\UserCollection::__construct(): Implicitly marking parameter $resourcePath as nullable is deprecated, the explicit nullable type must be used instead in ./src/Directory/Users/UserCollection.php on line 14
PHP Deprecated:  Office365\SharePoint\FieldCollection::__construct(): Implicitly marking parameter $resourcePath as nullable is deprecated, the explicit nullable type must be used instead in ./src/SharePoint/FieldCollection.php on line 17
PHP Deprecated:  Office365\SharePoint\FieldCollection::__construct(): Implicitly marking parameter $parent as nullable is deprecated, the explicit nullable type must be used instead in ./src/SharePoint/FieldCollection.php on line 17
PHP Deprecated:  Office365\SharePoint\ListItemCollection::__construct(): Implicitly marking parameter $resourcePath as nullable is deprecated, the explicit nullable type must be used instead in ./src/SharePoint/ListItemCollection.php on line 15
PHP Deprecated:  Office365\SharePoint\ListItemCollection::__construct(): Implicitly marking parameter $parent as nullable is deprecated, the explicit nullable type must be used instead in ./src/SharePoint/ListItemCollection.php on line 15
PHP Deprecated:  Office365\SharePoint\FolderCollection::__construct(): Implicitly marking parameter $resourcePath as nullable is deprecated, the explicit nullable type must be used instead in ./src/SharePoint/FolderCollection.php on line 23
PHP Deprecated:  Office365\SharePoint\FolderCollection::__construct(): Implicitly marking parameter $parent as nullable is deprecated, the explicit nullable type must be used instead in ./src/SharePoint/FolderCollection.php on line 23
```